### PR TITLE
[Fix] #91 MVOUT coarse-grained DMA

### DIFF
--- a/PyTorchSimFrontend/mlir/mlir_codegen_backend.py
+++ b/PyTorchSimFrontend/mlir/mlir_codegen_backend.py
@@ -815,7 +815,7 @@ class MLIRKernel(mlir_common.BaseMLIRKernel):
         code = f"affine.dma_start %{buffer}[%c0, %c0], %{var}[{prefix}{indices}], %{name}_tag[0], %c{dmaType}, %c{mm_stride}, %c{chunk} : memref<{tile_row}x{tile_col}x{type_name}, 1>, memref<{self.buffer_types[name][1]}x{type_name}>, memref<1xi32>"
         self.cse.generate(self.reductions_suffix, code, assignment = False)
 
-    def codegen_body(self, subtile):
+    def codegen_body(self):
         # if not (
         #     self.loads
         #     or self.stores
@@ -835,10 +835,6 @@ class MLIRKernel(mlir_common.BaseMLIRKernel):
         self.body.splice(self.compute)
         if len(self.stores._lines) == 0:
             template_store(self.render_options)
-        if subtile:
-            for i in range(len(self.stores._lines)):
-                if "affine.dma_start" in self.stores._lines[i]:
-                    self.stores._lines[i] += f" {{ subtile_size=[{self.vector_lane}, {self.vector_lane}], async=1 }}"
         self.body.splice(self.stores)
         self.loads.clear()
         self.compute.clear()

--- a/PyTorchSimFrontend/mlir/mlir_conv_template.py
+++ b/PyTorchSimFrontend/mlir/mlir_conv_template.py
@@ -48,7 +48,7 @@ func.func @{{ KERNEL_NAME }}({{ KERNEL_DEF }}) {
             linalg.matmul ins(%X_buffer, %W_buffer : memref<{{ TILE_M }}x{{ TILE_K }}x{{ DATA_STYPE }}, 1>, memref<{{ TILE_K }}x{{ TILE_N }}x{{ DATA_STYPE }}, 1>)
                     outs(%Y_buffer : memref<{{ TILE_M }}x{{ TILE_N }}x{{ DATA_STYPE }}, 1>)
         } { accumulation_loop=true }
-        affine.dma_start %Y_buffer[%c0, %c0], %Y[%index2], %tag[0], %c_mvout, %N, %c_set : memref<{{ TILE_M }}x{{ TILE_N }}xf32, 1>, memref<{{ M * N }}xf32>, memref<1xi32>  { subtile_size=[{{ kernel.vector_lane }}, {{ kernel.vector_lane }}], async=1 }
+        affine.dma_start %Y_buffer[%c0, %c0], %Y[%index2], %tag[0], %c_mvout, %N, %c_set : memref<{{ TILE_M }}x{{ TILE_N }}xf32, 1>, memref<{{ M * N }}xf32>, memref<1xi32>  { async=1 }
     } { outer_loop=true }
   } { outer_loop=true }
   return

--- a/PyTorchSimFrontend/mlir/mlir_gemm_template.py
+++ b/PyTorchSimFrontend/mlir/mlir_gemm_template.py
@@ -62,7 +62,7 @@ func.func @{{ KERNEL_NAME }}{{kernel.def_kernel(inputs=[X, W, Bias], outputs=[Y]
         linalg.matmul ins(%X_buffer, %W_buffer : memref<{{ TILE_M }}x{{ TILE_K }}x{{ DATA_STYPE }}, 1>, memref<{{ TILE_K }}x{{ TILE_N }}x{{ DATA_STYPE }}, 1>)
                 outs(%Y_buffer : memref<{{ TILE_M }}x{{ TILE_N }}x{{ DATA_STYPE }}, 1>)
       } { accumulation_loop=true }
-      {{kernel.store_output(subtile=True)}}
+      {{kernel.store_output()}}
     } { outer_loop=true }
   } { outer_loop=true }
   return

--- a/PyTorchSimFrontend/mlir/mlir_template.py
+++ b/PyTorchSimFrontend/mlir/mlir_template.py
@@ -207,9 +207,9 @@ class MLIRTemplateKernel(MLIRKernel, BaseMLIRHardwareInfo):
         self.render_hooks["<OUPUT>"] = hook
         return "<OUPUT>"
 
-    def store_output(self, subtile=False):
+    def store_output(self):
         def hook():
-            self.codegen_body(subtile=subtile)
+            self.codegen_body()
             return textwrap.indent(self.body.getvalue(), "      ").strip()  #TODO: First line is not indented
 
         assert "<STORE_OUTPUT>" not in self.render_hooks


### PR DESCRIPTION
As mvout does not need to operate with fine-grained, gemm and conv template code is fixed.

referenced: PSAL-POSTECH/llvm-project@62ec63c