### PR TITLE
[Optimize] index expr

### DIFF
--- a/PyTorchSimFrontend/mlir/mlir_common.py
+++ b/PyTorchSimFrontend/mlir/mlir_common.py
@@ -613,6 +613,10 @@ class BaseMLIRKernel(common.Kernel, BaseMLIRHardwareInfo):
                 return self.reduction(dtype, src_dtype, reduction_type, value)
 
             @staticmethod
+            def _index_expr(tile_size, buffer, renamed_expression, index):
+                return self._index_expr(tile_size, buffer, renamed_expression, index)
+
+            @staticmethod
             def index_expr(index, dtype):
                 return self.index_expr(index, dtype)
 

--- a/gem5_script/script_systolic.py
+++ b/gem5_script/script_systolic.py
@@ -160,6 +160,7 @@ class MinorVecConfig(MinorFU):
     opClasses = minorMakeOpClassSet(
         [
             "SimdConfig",
+            "CustomVlaneIdx",
         ]
     )
     opLat = 1


### PR DESCRIPTION
vector load should be placed in self.compute buffer

if the distance between load and compute, register spilling incurs