### PR TITLE
[CI] Set persist-credentials: false on actions/checkout

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           ref: ${{ env.SOURCE_SHA }}
           submodules: recursive
+          persist-credentials: false
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -90,6 +91,7 @@ jobs:
         with:
           ref: ${{ env.SOURCE_SHA }}
           submodules: recursive
+          persist-credentials: false
 
       - name: Login to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/docker-tutorial-image.yml
+++ b/.github/workflows/docker-tutorial-image.yml
@@ -16,6 +16,8 @@ jobs:
       # Step 1: Checkout the repository
       - name: Checkout Code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       # Step 2: Log in to GitHub Container Registry
       - name: Log in to GitHub Container Registry

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -24,6 +24,7 @@ jobs:
           repository: PSAL-POSTECH/PyTorchSim
           ref: ${{ github.sha }}
           submodules: recursive
+          persist-credentials: false
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -92,6 +93,7 @@ jobs:
           repository: PSAL-POSTECH/PyTorchSim
           ref: ${{ github.ref_name }}
           submodules: recursive
+          persist-credentials: false
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Sync Wiki
         uses: Andrew-Chen-Wang/github-wiki-action@v4


### PR DESCRIPTION
## Summary
- Add `persist-credentials: false` to every `actions/checkout@v4` invocation across `docker-image.yml`, `docker-tutorial-image.yml`, `tag_release.yml`, `wiki.yml` (6 checkouts in 4 files)
- Prevents `actions/checkout` from writing the short-lived `ghs_*` installation token into `.git/config` as `http.<host>.extraheader` after the workflow finishes
- Concrete problem this avoids: on self-hosted runners (`build-and-test`, `tag_release` build job, tutorial build) the work tree persists between jobs. An interrupted or killed workflow leaves the (later-expired) token in `.git/config`, which then breaks future `git fetch` / `git push` in that tree with `401 Invalid username or token` because the stale header is always sent first

## Notes
- None of the touched workflows run authenticated `git` operations after the checkout step — they all proceed straight to `docker/login-action` and `docker/build-push-action`. So losing the persisted credential has no behavioral impact.
- Public submodules (`booksim`, `ramulator2`, `stonne_core`, `onnx`, `protobuf`) don't need auth, so `submodules: recursive` checkouts are unaffected.
- `pytorchsim_test.yml` does not use `actions/checkout`, so nothing to change there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)