### PR TITLE
[CI] Register 5 previously-uncovered tests in pytorchsim_test.yml

### DIFF
--- a/.github/workflows/pytorchsim_test.yml
+++ b/.github/workflows/pytorchsim_test.yml
@@ -517,6 +517,22 @@ jobs:
             -e vpu_spad_size_kb_per_lane="${{ inputs.spad_size }}" \
             ${{ inputs.image_name }} python3 PyTorchSim/tests/Fusion/test_conv_fusion.py
 
+      - name: Run test_attention_fusion.py
+        run: |
+          echo "Running test_attention_fusion.py"
+          docker run --rm \
+            -e vpu_num_lanes="${{ inputs.vector_lane }}" \
+            -e vpu_spad_size_kb_per_lane="${{ inputs.spad_size }}" \
+            ${{ inputs.image_name }} python3 PyTorchSim/tests/Fusion/test_attention_fusion.py
+
+      - name: Run test_matmul_vector.py
+        run: |
+          echo "Running test_matmul_vector.py"
+          docker run --rm \
+            -e vpu_num_lanes="${{ inputs.vector_lane }}" \
+            -e vpu_spad_size_kb_per_lane="${{ inputs.spad_size }}" \
+            ${{ inputs.image_name }} python3 PyTorchSim/tests/Fusion/test_matmul_vector.py
+
   test_moe:
     name: Run test_moe
     runs-on: self-hosted
@@ -687,6 +703,63 @@ jobs:
             -e vpu_num_lanes="${{ inputs.vector_lane }}" \
             -e vpu_spad_size_kb_per_lane="${{ inputs.spad_size }}" \
             ${{ inputs.image_name }} python3 PyTorchSim/tests/DeepSeek/test_deepseek_v3_base.py
+
+  test_eager:
+    name: Run test_eager.py
+    runs-on: self-hosted
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run test_eager.py
+        run: |
+          echo "Running test_eager.py"
+          docker run --rm \
+            -e vpu_num_lanes="${{ inputs.vector_lane }}" \
+            -e vpu_spad_size_kb_per_lane="${{ inputs.spad_size }}" \
+            ${{ inputs.image_name }} python3 PyTorchSim/tests/test_eager.py
+
+  test_exponent:
+    name: Run test_exponent.py
+    runs-on: self-hosted
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run test_exponent.py
+        run: |
+          echo "Running test_exponent.py"
+          docker run --rm \
+            -e vpu_num_lanes="${{ inputs.vector_lane }}" \
+            -e vpu_spad_size_kb_per_lane="${{ inputs.spad_size }}" \
+            ${{ inputs.image_name }} python3 PyTorchSim/tests/test_exponent.py
+
+  test_sort:
+    name: Run test_sort.py
+    runs-on: self-hosted
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run test_sort.py
+        run: |
+          echo "Running test_sort.py"
+          docker run --rm \
+            -e vpu_num_lanes="${{ inputs.vector_lane }}" \
+            -e vpu_spad_size_kb_per_lane="${{ inputs.spad_size }}" \
+            ${{ inputs.image_name }} python3 PyTorchSim/tests/test_sort.py
 
   test_accuracy:
     name: Run test_accuracy and test_speedup


### PR DESCRIPTION
## Summary
Adds five `tests/` files that previously existed in the repo but were not in the CI allowlist, locally verified before registration:

| Test | Where in YAML |
|---|---|
| `tests/test_eager.py` | new top-level job `test_eager` |
| `tests/test_exponent.py` | new top-level job `test_exponent` |
| `tests/test_sort.py` | new top-level job `test_sort` |
| `tests/Fusion/test_attention_fusion.py` | new step inside `test_fusion` job |
| `tests/Fusion/test_matmul_vector.py` | new step inside `test_fusion` job |

All five were run locally against `origin/develop` and passed.

## Intentionally deferred

| Test | Reason |
|---|---|
| `tests/test_gqa.py`, `tests/test_gqa_decode.py` | WIP GQA SDPA path, tracked by #198 |
| `tests/test_sdpa.py` | overlaps with in-flight SDPA template work; ambiguous about which backend it exercises |
| `tests/test_topk.py` | sort-family coverage now provided by `test_sort` (stable + unstable + duplicate-key); revisit if topk-specific shapes/dims need separate gating |
| `tests/test_group_conv.py` | not run locally yet (stress config); follow-up after runtime cost is understood |
| `tests/test_vectorops.py` | cross-test imports (`from tests.test_add import ...`) are fragile; needs a helper-module extraction first |

This closes the most obvious accidental-omission gaps in the allowlist documented in CLAUDE.md (`docs/ci-test-allowlist` PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)