### PR TITLE
[Frontend] Fix SDPA decomposition NameError when attention mask is provided

### DIFF
--- a/PyTorchSimFrontend/mlir/mlir_decomposition.py
+++ b/PyTorchSimFrontend/mlir/mlir_decomposition.py
@@ -342,10 +342,12 @@ def decompose_native_multi_head_attention(
 
     # Step 4: Apply mask if provided
     if mask is not None:
+        attn_bias = torch.zeros_like(scores)
         if mask.dtype == torch.bool:
-            attn_bias.masked_fill_(mask.logical_not(), float("-inf"))
+            attn_bias = attn_bias.masked_fill(mask.logical_not(), float("-inf"))
         else:
-            attn_bias = mask + attn_bias
+            attn_bias = attn_bias + mask
+        scores = scores + attn_bias
 
     # Step 5: Softmax along the last dimension (seq_len dimension)
     attn_weights = F.softmax(scores, dim=-1)  # [batch, num_heads, seq_len, seq_len]


### PR DESCRIPTION
## Summary
Fixes issue #236.

`decompose_native_multi_head_attention` in `PyTorchSimFrontend/mlir/mlir_decomposition.py` referenced `attn_bias` before it was defined, so any call with a non-None `mask` raised `NameError`. The same block also computed `attn_bias` but never folded it into `scores` before `F.softmax`, so even if `attn_bias` had existed, the mask would have had no effect on attention weights.

## Change
```python
# Step 4: Apply mask if provided
if mask is not None:
    attn_bias = torch.zeros_like(scores)
    if mask.dtype == torch.bool:
        attn_bias = attn_bias.masked_fill(mask.logical_not(), float("-inf"))
    else:
        attn_bias = attn_bias + mask
    scores = scores + attn_bias
```

- Initialize `attn_bias` from `scores` (correct shape/dtype/device).
- Use out-of-place `masked_fill` / addition (safer for autograd if it ever propagates through this decomposition).
- Add the bias to `scores` before softmax so the mask actually affects attention.

## Why this matters
Any model that hits this decomposition path with a causal or padding mask currently crashes with `NameError: name 'attn_bias' is not defined`. The decomposition is registered for `aten._native_multi_head_attention.default`, which is reached for `nn.MultiheadAttention` / `F.multi_head_attention_forward` when the SDPA fast-path is not selected.

## Out of scope (separate follow-up)
- The decomposition signature does not yet match the full aten op: `aten._native_multi_head_attention.default` also takes `average_attn_weights` and `mask_type`. These are not handled here; this PR is the minimal fix for the masked-attention NameError only.
- No new test added in this PR because there is no MHA test in the repo today and adding one needs a config that exercises the decomposition path rather than the SDPA template. Worth doing in a follow-up.