### PR TITLE
[Frontend] Fix four codegen correctness issues surfaced by review

### DIFF
--- a/PyTorchSimFrontend/extension_codecache.py
+++ b/PyTorchSimFrontend/extension_codecache.py
@@ -271,7 +271,7 @@ class CustomAsyncCompile(AsyncCompile):
         autotune = kwargs.get('autotune', False)
         def task():
             key = MLIRCodeCache.load(source_code,
-                                          valdiation_wrapper_name=self.validation_binary_name,
+                                          validation_wrapper_name=self.validation_wrapper_name,
                                           validation_binary_name=self.validation_binary_name,
                                           arg_attributes=arg_attributes, vectorlane_size=vectorlane_size,
                                           tile_size=tile_size, spad_info=spad_info, origins=origins,

--- a/PyTorchSimFrontend/mlir/mlir_codegen_backend.py
+++ b/PyTorchSimFrontend/mlir/mlir_codegen_backend.py
@@ -170,11 +170,11 @@ class ExtensionWrapperCodegen(wrapper.PythonWrapperCodegen):
 
     def codegen_sram_plan_prefix(self):
         for name, buf in V.graph.graph_inputs.items():
+            if buf is None:
+                continue
             if isinstance(buf, sympy.Expr):
                 continue
             if sympy_product(buf.get_size()) == 0:
-                continue
-            if buf is None:
                 continue
             self.prefix.writeline(f"sram_plan_prefix('{name}', {name})")
 
@@ -907,7 +907,7 @@ class MLIRKernel(mlir_common.BaseMLIRKernel):
             loops = LoopNest([LoopLevel("dummy", 1)])
 
         if len(reductions.loops) > 1:
-            NotImplementedError("Not support multiple reduction axis..")
+            raise NotImplementedError("Not support multiple reduction axis..")
 
         code.splice(self.const_buffer)
         code.splice(self.alloc_buffer)

--- a/PyTorchSimFrontend/mlir/mlir_common.py
+++ b/PyTorchSimFrontend/mlir/mlir_common.py
@@ -1027,10 +1027,6 @@ class BaseMLIRKernel(common.Kernel, BaseMLIRHardwareInfo):
                 return self.reduction(dtype, src_dtype, reduction_type, value)
 
             @staticmethod
-            def check_bounds(index, size, lower, upper):
-                return self.check_bounds(index, size, lower, upper)
-
-            @staticmethod
             def _index_expr(tile_size, buffer, renamed_expression, index):
                 return self._index_expr(tile_size, buffer, renamed_expression, index)
 


### PR DESCRIPTION
## Summary
Fixes issue #237. Four small but real correctness issues in the MLIR codegen / cache layer, fixed together since each is just one line.

Net diff: **3 files, +4 / -8**.

## Fixes

### 1. `NotImplementedError` constructed but not raised
`mlir_codegen_backend.py:909` — kernels with more than one reduction axis silently fell through to incorrect codegen.
```diff
- NotImplementedError("Not support multiple reduction axis..")
+ raise NotImplementedError("Not support multiple reduction axis..")
```

### 2. `buf.get_size()` accessed before None check
`mlir_codegen_backend.py:171-179` — if any `graph_inputs` entry is `None`, the existing guards would `AttributeError` before reaching the `is None` check. Reorder so `None` is rejected first.
```diff
  for name, buf in V.graph.graph_inputs.items():
+     if buf is None:
+         continue
      if isinstance(buf, sympy.Expr):
          continue
      if sympy_product(buf.get_size()) == 0:
          continue
-     if buf is None:
-         continue
```

### 3. Duplicate `check_bounds` static method
`mlir_common.py` had two identical `@staticmethod def check_bounds(...)` declarations inside `CSEProxy`. Python silently keeps only the latter; the first was dead. Drop the duplicate (kept the earlier one, sited next to `indirect_indexing` where it semantically belongs).

### 4. `valdiation_wrapper_name` kwarg typo
`extension_codecache.py:274` — `CustomAsyncCompile.mlir` passed the misspelled keyword `valdiation_wrapper_name` carrying `self.validation_binary_name`. The misspelled kwarg was absorbed by `**kwargs` and discarded, so `MLIRCodeCache.load`'s real `validation_wrapper_name` parameter fell back to its default `"validation_wrapper"`. By coincidence that matches `self.validation_wrapper_name`, so it worked today — but the intent is clearly to pass `self.validation_wrapper_name`, and any future refactor of either default would break it silently.
```diff
- valdiation_wrapper_name=self.validation_binary_name,
+ validation_wrapper_name=self.validation_wrapper_name,
```

## Risk
- (1) and (2) are guards that previously never fired in CI (or fired silently with wrong codegen); they should not change behavior for already-passing tests.
- (3) is dead-code removal; the surviving definition is identical.
- (4) preserves the current effective value (`"validation_wrapper"`) by accident; this PR just makes the intent explicit. No runtime behavior change expected.

Local sanity: a few `python tests/test_*.py` smoke runs pass.