### PR TITLE
[Frontend] Drop unused TOG host-cflags/ldflags config (issue #239)

### DIFF
--- a/PyTorchSimFrontend/extension_config.py
+++ b/PyTorchSimFrontend/extension_config.py
@@ -8,37 +8,6 @@ CONFIG_TORCHSIM_DIR = os.environ.get('TORCHSIM_DIR', default='/workspace/PyTorch
 CONFIG_GEM5_PATH = os.environ.get('GEM5_PATH', default="/workspace/gem5/build/RISCV/gem5.opt")
 CONFIG_TORCHSIM_LLVM_PATH = os.environ.get('TORCHSIM_LLVM_PATH', default="/usr/bin")
 
-CONFIG_TORCHSIM_TOG_HOST_CC = os.environ.get("TORCHSIM_TOG_HOST_CC", "gcc")
-
-def _default_tog_host_cflags():
-    """Host flags for ``dlopen``'d ``*_tog.so`` / ``tile_operation_graph.so``."""
-    if os.environ.get("TORCHSIM_TOG_HOST_CFLAGS"):
-        return os.environ["TORCHSIM_TOG_HOST_CFLAGS"]
-    if True: #int(os.environ.get("TORCHSIM_TOG_SO_DEBUG", "0")):
-        return (
-            "-g -Og -fno-omit-frame-pointer -fPIC -std=c11 "
-            "-Wall -Wextra -Wno-unused-variable -Wno-unused-parameter"
-        )
-    return (
-        "-O2 -fPIC -std=c11 -Wall -Wextra -Wno-unused-variable -Wno-unused-parameter"
-    )
-
-
-CONFIG_TORCHSIM_TOG_HOST_CFLAGS = _default_tog_host_cflags()
-
-
-def _default_tog_host_ldflags():
-    if os.environ.get("TORCHSIM_TOG_HOST_LDFLAGS"):
-        return os.environ["TORCHSIM_TOG_HOST_LDFLAGS"]
-    # Keep debug sections in .so; optional build-id helps GDB locate DWARF.
-    base = "-shared"
-    if int(os.environ.get("TORCHSIM_TOG_SO_DEBUG", "0")):
-        return base + " -Wl,--build-id"
-    return base
-
-
-CONFIG_TORCHSIM_TOG_HOST_LDFLAGS = _default_tog_host_ldflags()
-
 CONFIG_TORCHSIM_DUMP_MLIR_IR = int(os.environ.get("TORCHSIM_DUMP_MLIR_IR", default=False))
 CONFIG_TORCHSIM_DUMP_LLVM_IR = int(os.environ.get("TORCHSIM_DUMP_LLVM_IR", default=False))
 


### PR DESCRIPTION
## Summary
Removes `CONFIG_TORCHSIM_TOG_HOST_{CC,CFLAGS,LDFLAGS}` and the two `_default_tog_host_{cflags,ldflags}()` helpers from `PyTorchSimFrontend/extension_config.py`. Net diff: 1 file changed, 31 deletions(-).

Closes #239.

## Why drop instead of restoring the env-var gate
Issue #239 reports that `_default_tog_host_cflags()` carries an `if True: #int(os.environ.get("TORCHSIM_TOG_SO_DEBUG", "0")):` shortcut and proposes restoring the original env-var gate. That fix would be correct *if* the constant were consumed — but it isn't.

`grep` across `.py`/`.cc`/`.cpp`/`.h*` shows the three `CONFIG_TORCHSIM_TOG_HOST_*` names are referenced **only** at the definition site. `MLIRCodeCache._load_library` (the natural caller) is still a `pass` stub. So no `*_tog.so` is actually being compiled with `-Og`; the perf cost the issue describes never materialised.

Tracing `git log -S "if True: #int(os.environ"`: introduced in `54ccd4c` (\"[Frontend] Put TorchInductor cache under TORCHSIM_DUMP_PATH\", 2026-04-07), where the helpers were added as a side change alongside the main `TORCHINDUCTOR_CACHE_DIR` rewrite and never wired up.

## Future-proofing
If the host-side TOG `.so` compile path is wired up later, the env-var gate should be reintroduced at the actual call site (or near it), not as orphan module-level constants.

## Test plan
- [x] `python3 -m py_compile PyTorchSimFrontend/extension_config.py`
- [x] Grep for residual references across the repo — clean (only a stale memory note in `.claude/`, untracked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)