### PR TITLE
[Frontend] Drop stale single-reduction-axis guard breaking test_diffusion

### DIFF
--- a/PyTorchSimFrontend/mlir/mlir_codegen_backend.py
+++ b/PyTorchSimFrontend/mlir/mlir_codegen_backend.py
@@ -906,9 +906,6 @@ class MLIRKernel(mlir_common.BaseMLIRKernel):
         if (self.reduction_depth==0):
             loops = LoopNest([LoopLevel("dummy", 1)])
 
-        if len(reductions.loops) > 1:
-            raise NotImplementedError("Not support multiple reduction axis..")
-
         code.splice(self.const_buffer)
         code.splice(self.alloc_buffer)
         code.splice(self.spad_buffer)


### PR DESCRIPTION
## Summary
Removes the dead guard at \`mlir_codegen_backend.py:909-910\`. The guard claimed multi-axis reduction was unsupported, but the codegen below it actually iterates all reduction loops and produces correct output — \`test_diffusion\`, added specifically to validate multi-axis support, passed for ~9 months while this guard had no \`raise\` and was effectively a no-op.

PR #237 (5045837) added a \`raise\` to the guard as part of a four-item correctness fix. The intent ("missing raise") was correct in form but wrong in substance: the *guard itself* was stale. With the raise added, every diffusion CI run now fails at this guard.

## Timeline
1. \`8eacf27\` (early 2025): reduce/elementwise refactor restricted codegen to \`reductions.loops[0]\` and added the guard (no raise — silently dead).
2. \`c61f67d\` "Support multi reduction dim + Add Diffusion model test" (2025-08-14): restored \`for reduction_loop in reductions.loops:\` iteration to support multi-axis. test_diffusion added in the same commit, passed. Guard left behind.
3. \`5045837\` (#237 fix, 2026-05-26): added \`raise\` to the guard. test_diffusion now fails — *the very test added by* \`c61f67d\` *to prove multi-axis works*.

## Evidence the codegen handles multi-axis
- \`test_diffusion\` (UNet2DConditionModel) passed under develop@\`48c4979\` while exercising this code path with multiple reduction loops, output checked via \`torch.allclose(rtol=atol=1e-4)\`.
- The iteration that emits the loops (\`for reduction_loop in reductions.loops:\` with proper \`code.indent(...)\` per loop) is structurally correct for N loops.

## Scope
- Touches only the guard. The other three items fixed in #237 (codegen_sram_plan_prefix None check, CSEProxy duplicate check_bounds, etc.) are correct and unrelated; not touched.

Fixes the diffusion failures observed on PR CI runs since \`5045837\` landed on develop (e.g. run #404, #418).

## Test plan
- [x] \`python3 -m py_compile\` on \`mlir_codegen_backend.py\`
- [ ] CI: test_diffusion (wrapper1 + wrapper2) — should return to pre-#237 passing state

🤖 Generated with [Claude Code](https://claude.com/claude-code)