### PR TITLE
[Experiment] Fix BERT.py imports and fail-fast in run_cycle.sh

### DIFF
--- a/experiments/BERT.py
+++ b/experiments/BERT.py
@@ -4,6 +4,7 @@ import argparse
 
 base_path = os.environ.get('TORCHSIM_DIR', default='/workspace/PyTorchSim')
 sys.path.insert(0, base_path)
+sys.path.insert(0, os.path.join(base_path, 'tests'))
 
 import torch
 from Simulator.simulator import TOGSimulator
@@ -13,9 +14,9 @@ os.environ['TOGSIM_CONFIG'] = config
 
 # Try Fusion EncoderBlock first, fall back to standard test_transformer
 try:
-    from tests.Fusion.test_transformer_fusion import EncoderBlock
+    from ops.fusion.test_transformer_fusion import EncoderBlock
 except ImportError:
-    from tests.test_transformer import EncoderBlock
+    from models.test_transformer import EncoderBlock
 
 HIDDEN_DIM = {'base': 768, 'large': 1024, 'xlarge': 2048}
 EMBEDDING_SIZE = {'base': 768, 'large': 1024, 'xlarge': 2048}

--- a/experiments/artifact/cycle_validation/run_cycle.sh
+++ b/experiments/artifact/cycle_validation/run_cycle.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-set -e
+# pipefail so a failing "python3 ... | tee log" aborts instead of being masked by
+# tee's exit code (otherwise a broken model -- e.g. BERT -- fails silently and the
+# job stays green).
+set -eo pipefail
 
 usage() {
   cat <<'EOF'


### PR DESCRIPTION
Two independent fixes surfaced while reviewing the test_accuracy CI job (unrelated to floor/mod work).

**BERT.py imports broken by the tests/ reorg.** `experiments/BERT.py` still imported `EncoderBlock` from `tests.Fusion.test_transformer_fusion` / `tests.test_transformer`, which no longer exist (moved to `tests/ops/fusion` and `tests/models`). Every BERT size raised `ModuleNotFoundError`. Fixed by putting `tests/` on sys.path and importing `ops.fusion.test_transformer_fusion` / `models.test_transformer` (same convention the test files use).

**run_cycle.sh masked failures.** Each model ran as `python3 ... | tee log` under `set -e` only, so a crash was hidden by tee's exit code -- the job stayed green with empty logs. This is why broken BERT went unnoticed. Added `set -o pipefail` so a failing model aborts.

Verified: `BERT.py --size base` now runs end to end (TOGSim, 329573 cycles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)