### PR TITLE
[Frontend] vcix: lower fused matmul whose operand is vector_store'd, fix exp chunking

### DIFF
--- a/PyTorchSimFrontend/mlir/passes/lower_to_vcix.py
+++ b/PyTorchSimFrontend/mlir/passes/lower_to_vcix.py
@@ -113,9 +113,10 @@ def _make_sf_vc_v_iv(vec, op_vt, n, legal_ty, opcode, imm):
     else:
         for i in range(total // elt_count):
             ext = vector.ExtractStridedSliceOp(
+                legal_ty, vec,
                 ir.ArrayAttr.get([_i64(i * elt_count)]),
                 ir.ArrayAttr.get([_i64(elt_count)]),
-                ir.ArrayAttr.get([_i64(1)]), vec).result
+                ir.ArrayAttr.get([_i64(1)])).result
             v = _viv(ext, legal_ty, opcode, imm, rvl)
             res = vector.InsertStridedSliceOp(
                 v, res, ir.ArrayAttr.get([_i64(i * elt_count)]),
@@ -364,7 +365,28 @@ def _lower_matmul(op, SS, vlen):
     AAsync = BAsync = BiasAsync = 0
     BiasIdx = None
     subtileM, subtileN, subtileK = M, N, K
+    # Mirror the C++ isAInitialized / isBInitialized flags: an operand is
+    # "initialized" either by an MVIN dma_start (tag found below) or by a
+    # preceding affine.vector_store into its root memref (the fused case, e.g.
+    # SDPA scores.V where B is the softmax output produced in-place, not DMAed).
+    isAInit = isBInit = False
+
+    def _root(v):
+        owner = v.owner
+        if not isinstance(owner, ir.Block):
+            nm = owner.name
+            if nm in ("memref.reinterpret_cast", "memref.cast"):
+                return owner.operands[0]
+        return v
+    rootA, rootB = _root(A), _root(B)
     for o in _iter_ops(outer[-1].regions[0].blocks[0]):
+        if o.operation.name == "affine.vector_store":
+            dest = _root(o.operation.operands[1])
+            if dest == rootA:
+                isAInit = True
+            elif dest == rootB:
+                isBInit = True
+            continue
         if o.operation.name != "memref.dma_start":
             continue
         d = _DmaView(o.operation)
@@ -380,16 +402,18 @@ def _lower_matmul(op, SS, vlen):
         sub = d.subtile_size()
         if argn == idxMap[0]:
             ATag, AAsync = d.tag, d.is_async()
+            isAInit = True
             if len(sub) >= 2:
                 subtileM, subtileK = sub[-2], sub[-1]
         elif argn == idxMap[1]:
             BTag, BAsync = d.tag, d.is_async()
+            isBInit = True
             if len(sub) >= 2:
                 subtileK, subtileN = sub[-2], sub[-1]
         elif argn == idxMap[2]:
             BiasTag, BiasAsync = d.tag, d.is_async()
             BiasIdx = d.tag_idx
-    if ATag is None or BTag is None:
+    if not isAInit or not isBInit:
         return False
 
     KStep = subtileK


### PR DESCRIPTION
Fixes SDPA, which was broken on this branch by the C++->Python vcix port (`lower_to_vcix.py`). Bisected decisively: **C++ vcix passes SDPA, Python vcix does not**; exp-chunking and dma-fine-grained were ruled out, leaving `_lower_matmul`.

**1. Fused matmul left un-lowered (the numerical bug).** `_lower_matmul` bailed on `ATag is None or BTag is None` -- i.e. it required an MVIN `dma_start` tag for both operands. In SDPA's `scores·V` matmul, operand B is the softmax output produced **in place by `affine.vector_store`**, not DMAed, so `BTag` stayed `None` and the matmul was left in the IR -> wrong attention output. The C++ `MatmulOpLowering` marks an operand initialized by **either** a `dma_start` **or** a preceding `affine.vector_store` into its root memref; the Python port omitted that branch. Restored it (`isAInit`/`isBInit`). `BTag`/`BAsync` stay `None`/0 and are only read under `if BAsync:`, so the B `dma_wait` is correctly skipped, matching C++.

**2. n>1 transcendental chunking crash.** `_make_sf_vc_v_iv` called `vector.ExtractStridedSliceOp(offsets, sizes, strides, vec)` -- wrong arg order, missing the result type and vector operand -> `TypeError` under these MLIR bindings. Fixed to `(result=legal_ty, vector=vec, offsets, sizes, strides)`. Only large transcendentals (n>1, e.g. SDPA softmax exp) reach it, so CI's small-tile (n==1) tests never hit it.

Validated end-to-end (Spike+TOGSim allclose): **SDPA 56 cases pass** (was crash/wrong); matmul/bmm/conv2d regress clean. Pass-level: after the fix the Python vcix output is byte-identical to `mlir-opt -test-pytorchsim-to-vcix` for the SDPA kernel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)