### PR TITLE
[Frontend] Unify in-process MLIR passes under one phase-list driver

### DIFF
--- a/PyTorchSimFrontend/extension_codecache.py
+++ b/PyTorchSimFrontend/extension_codecache.py
@@ -132,7 +132,10 @@ class MLIRCodeCache:
         # Run the Python out-of-line MLIR passes (MLIR bindings) on the kernel
         # .mlir in place, before mlir-opt. Currently lowers torchsim.vlane_idx
         # (replaces the old C++ -global-idx pass); add more in passes/__init__.py.
-        from PyTorchSimFrontend.mlir.passes import run_python_passes, run_standard_lowering, run_tog, run_fine_grained, run_to_vcix
+        from PyTorchSimFrontend.mlir.passes import (
+            run_python_passes, run_module_passes, POST_OPT_PASSES,
+            run_standard_lowering, run_tog,
+        )
         run_python_passes(input_path, vectorlane=vectorlane_size)
         new_input_path = os.path.splitext(input_path)[0]
         raw_tog_path = new_input_path + "_tog.py"
@@ -160,12 +163,11 @@ class MLIRCodeCache:
             llc_asm_cmd = shlex.split(cmds[3])
             with lock:
                 try:
-                    # loop-padding (mlir-opt) -> Python fine-grained -> Python vcix
+                    # loop-padding (mlir-opt) -> Python fine-grained + vcix (one parse/print)
                     subprocess.check_call(opt_pad_cmd)
-                    run_fine_grained(new_input_path + "_padded.mlir",
-                                     new_input_path + "_padded.mlir", vectorlane_size)
-                    run_to_vcix(new_input_path + "_padded.mlir",
-                                new_input_path + "_custom.mlir", vectorlane_size, vlen)
+                    run_module_passes(new_input_path + "_padded.mlir",
+                                      new_input_path + "_custom.mlir",
+                                      POST_OPT_PASSES, vectorlane=vectorlane_size, vlen=vlen)
                     # Standard MLIR -> LLVM-dialect lowering (registered upstream
                     # passes) runs in-process via the bindings PassManager, picking
                     # up after the custom mlir-opt passes (memref-to-gemmini).
@@ -210,12 +212,11 @@ class MLIRCodeCache:
                 # to Python: run_tog reads that IR, writes the TOG (_tog.py) and the
                 # mutated IR (_custom.mlir: sample-mode step rewrite + compute markers),
                 # replacing the C++ -test-tile-operation-graph pass.
-                # loop-padding(timing, mlir-opt) -> Python fine-grained -> Python vcix
+                # loop-padding(timing, mlir-opt) -> Python fine-grained + vcix (one parse/print)
                 subprocess.check_call(gem5_pad_cmd)
-                run_fine_grained(sample_mlir_path + "_padded.mlir",
-                                 sample_mlir_path + "_padded.mlir", vectorlane_size)
-                run_to_vcix(sample_mlir_path + "_padded.mlir",
-                            sample_mlir_path + "_postvcix.mlir", vectorlane_size, vlen)
+                run_module_passes(sample_mlir_path + "_padded.mlir",
+                                  sample_mlir_path + "_postvcix.mlir",
+                                  POST_OPT_PASSES, vectorlane=vectorlane_size, vlen=vlen)
                 run_tog(sample_mlir_path + "_postvcix.mlir", raw_tog_path,
                         sample_mlir_path + "_custom.mlir",
                         sample_mode=extension_config.CONFIG_TLS_MODE,

--- a/PyTorchSimFrontend/mlir/passes/__init__.py
+++ b/PyTorchSimFrontend/mlir/passes/__init__.py
@@ -32,34 +32,39 @@ _ensure_mlir_bindings_on_path()
 
 from . import lower_vlane_idx
 from . import decompose_transfer
+from . import dma_fine_grained
+from . import lower_to_vcix
 from .lower_to_llvm import run_standard_lowering  # noqa: F401 (re-exported)
 from .build_tog import run_tog  # noqa: F401 (re-exported; replaces C++ test-tile-operation-graph)
-from .dma_fine_grained import run_fine_grained  # noqa: F401 (replaces C++ -dma-fine-grained)
-from .lower_to_vcix import run_to_vcix  # noqa: F401 (replaces C++ -test-pytorchsim-to-vcix)
+from .dma_fine_grained import run_fine_grained  # noqa: F401 (re-exported; standalone/CLI)
+from .lower_to_vcix import run_to_vcix  # noqa: F401 (re-exported; standalone/CLI)
 
-# Ordered passes applied to each kernel .mlir before mlir-opt.
-# decompose_transfer first: it lowers togsim.transfer -> memref.dma_start, which
-# downstream passes (and the gemmini lowering) expect.
-PASSES = [
+# Module rewrite passes around the one remaining mlir-opt pass (-test-loop-padding).
+# Each exposes MARKERS + run(module, **opts); run_module_passes parses once per phase.
+# decompose_transfer first: togsim.transfer -> memref.dma_start (downstream expects it).
+PRE_OPT_PASSES = [
     decompose_transfer,
     lower_vlane_idx,
 ]
+# fine-grained first: splits the matmul DMAs that the vcix lowering then reads.
+POST_OPT_PASSES = [
+    dma_fine_grained,
+    lower_to_vcix,
+]
 
 
-def run_python_passes(mlir_path, vectorlane=128):
-    """Apply all registered Python MLIR passes to the .mlir at `mlir_path`, in place.
-
-    `vectorlane` (systolic-array size / number of vector lanes) is forwarded to passes
-    that need it (e.g. decompose_transfer's lane-banked >4D peel).
-
-    Returns True if the file was modified, False otherwise.
-    """
-    with open(mlir_path) as f:
+def run_module_passes(in_path, out_path, passes, **opts):
+    """Parse `in_path` once, run each marker-matched pass on the shared Module in
+    order, print once to `out_path` (in place if equal). `opts` forwarded to each
+    run(module, **opts). Returns True if any pass ran."""
+    with open(in_path) as f:
         text = f.read()
 
-    # Fast path: nothing to do if no pass's target op appears in the text.
-    active = [p for p in PASSES if any(mk in text for mk in p.MARKERS)]
+    active = [p for p in passes if any(mk in text for mk in p.MARKERS)]
     if not active:
+        if out_path != in_path:
+            import shutil
+            shutil.copyfile(in_path, out_path)
         return False
 
     from mlir.ir import Context, Module, Location
@@ -68,9 +73,14 @@ def run_python_passes(mlir_path, vectorlane=128):
     with ctx, Location.unknown():
         module = Module.parse(text)
         for p in active:
-            p.run(module, vectorlane=vectorlane)
+            p.run(module, **opts)
         out = str(module)
 
-    with open(mlir_path, "w") as f:
+    with open(out_path, "w") as f:
         f.write(out)
     return True
+
+
+def run_python_passes(mlir_path, vectorlane=128):
+    """Run the pre-mlir-opt Module passes (PRE_OPT_PASSES) on `mlir_path`, in place."""
+    return run_module_passes(mlir_path, mlir_path, PRE_OPT_PASSES, vectorlane=vectorlane)

--- a/PyTorchSimFrontend/mlir/passes/dma_fine_grained.py
+++ b/PyTorchSimFrontend/mlir/passes/dma_fine_grained.py
@@ -30,6 +30,8 @@ if os.path.isdir(_DEFAULT_BINDINGS) and _DEFAULT_BINDINGS not in sys.path:
 
 import mlir.ir as ir  # noqa: E402
 
+MARKERS = ("subtile_size",)   # only subtile DMAs are split
+
 MVIN, MVIN2, MVIN3, MVOUT = 2, 1, 14, 3
 
 # Per-rank subtile loop order and the fused-loop layout (mirror the C++ loopGroups).

--- a/PyTorchSimFrontend/mlir/passes/lower_to_vcix.py
+++ b/PyTorchSimFrontend/mlir/passes/lower_to_vcix.py
@@ -29,6 +29,8 @@ if os.path.isdir(_DEFAULT_BINDINGS) and _DEFAULT_BINDINGS not in sys.path:
 
 import mlir.ir as ir  # noqa: E402
 
+MARKERS = ("linalg.matmul", "math.exp", "math.erf", "math.tanh", "math.sin", "math.cos")
+
 # math op name -> (opcode, imm) for the vcix.v.iv lowering (mirror Math*ToVCIX).
 _MATH_VIV = {
     "math.exp":  (0b000011, 0),


### PR DESCRIPTION
Level 1 cleanup of the Python-binding custom-pass management.

**Before:** `decompose_transfer`/`lower_vlane_idx` were registered (`PASSES` + `run_python_passes`, one parse/print, marker-gated), but `dma_fine_grained`/`lower_to_vcix` -- which already expose the same `run(module, **opts)` interface -- were called file-based directly from `extension_codecache`. So between loop-padding and the standard lowering the .mlir was parsed+printed **twice** (once per pass), and the pipeline was hardcoded and duplicated across the functional and gem5 paths.

**After:** give both passes `MARKERS`, group the four rewrite passes into `PRE_OPT_PASSES` / `POST_OPT_PASSES` around the one remaining mlir-opt pass (`-test-loop-padding`), and drive them with a single `run_module_passes(in, out, passes, **opts)` that parses once, runs each marker-matched pass on the shared Module in order, prints once (copies through when no marker matches). `run_python_passes` is now PRE_OPT via that driver; the functional/gem5 `fine_grained`+`vcix` calls each collapse to one `run_module_passes`. `run_fine_grained`/`run_to_vcix` stay re-exported for standalone/CLI.

Net: one parse/print instead of two between loop-padding and lowering, one driver, 'add a pass = one line in a list'. `build_tog`/`run_standard_lowering` stay separate (TOG sidecar generator / LLVM PassManager, not pure Module rewrites).

Validated (Spike+TOGSim allclose): elementwise (no-marker passthrough), gemm, conv2d, softmax (exp -> vcix only, fine-grained skipped by marker), floor/mod suite (pre-opt), SDPA -- all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)