### PR TITLE
[CI] Fix integer widening (Spike v1.0.2) + regression test

### DIFF
--- a/.github/workflows/pytorchsim_test.yml
+++ b/.github/workflows/pytorchsim_test.yml
@@ -191,6 +191,25 @@ jobs:
             -e vpu_spad_size_kb_per_lane="${{ inputs.spad_size }}" \
             ${{ inputs.image_name }} python3 PyTorchSim/tests/ops/view/test_floormod_axis_split.py
 
+  test_widen_dtype:
+    name: Run test_widen_dtype.py
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run test_widen_dtype.py
+        run: |
+          echo "Running test_widen_dtype.py"
+          docker run --rm \
+            -e vpu_num_lanes="${{ inputs.vector_lane }}" \
+            -e vpu_spad_size_kb_per_lane="${{ inputs.spad_size }}" \
+            ${{ inputs.image_name }} python3 PyTorchSim/tests/ops/misc/test_widen_dtype.py
+
   test_matmul:
     name: Run test_matmul.py
     runs-on: ubuntu-latest

--- a/tests/ops/misc/test_widen_dtype.py
+++ b/tests/ops/misc/test_widen_dtype.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import torch
+sys.path.insert(0, os.path.join(os.environ.get("TORCHSIM_DIR", default="/workspace/PyTorchSim"), "tests"))
+from _pytorchsim_utils import test_result
+
+
+def _widen(device, name, src_dtype, dst_dtype, lo, hi):
+    # Widening conversions lower to vsext.vf*/vzext.vf* (VI_VV_EXT). A Spike bug
+    # wrote every lane's result to lane 1 (vu_idx dropped), zeroing the rest; this
+    # guards against that regression. Signed / uint8<128 only, so the sign-extension
+    # is correct independent of the separate uint8->int8 dtype issue (#238).
+    a = torch.randint(lo, hi, (128, 128), dtype=src_dtype)
+    fn = lambda a: a.to(dst_dtype)
+    res = torch.compile(dynamic=False)(fn)(a.to(device=device))
+    out = fn(a)
+    test_result(name, res, out)
+
+
+def test_widen(device):
+    _widen(device, "int8->int16",    torch.int8,  torch.int16,  -128, 128)
+    _widen(device, "int8->int32",    torch.int8,  torch.int32,  -128, 128)
+    _widen(device, "int16->int32",   torch.int16, torch.int32, -1000, 1000)
+    _widen(device, "uint8->int32",   torch.uint8, torch.int32,     0, 128)
+    _widen(device, "uint8->float32", torch.uint8, torch.float32,   0, 128)
+
+
+if __name__ == "__main__":
+    device = torch.device("npu:0")
+    test_widen(device)

--- a/thirdparty/github-releases.json
+++ b/thirdparty/github-releases.json
@@ -13,7 +13,7 @@
   },
   "spike": {
     "repository": "PSAL-POSTECH/riscv-isa-sim",
-    "release_tag": "v1.0.1",
+    "release_tag": "v1.0.2",
     "asset_name": "spike-release.tar.gz"
   }
 }


### PR DESCRIPTION
Fixes integer widening dtype conversions (`int8/int16 -> wider` via `tensor.to`), which were silently scrambled/zeroed.

**Root cause (Spike):** widening lowers to `vsext.vf*`/`vzext.vf*` (VI_VV_EXT). Spike wrote each result via `elt<T>(rd_num, i, true)` -- the literal `true` bound to the `vu_idx` parameter, so every lane's result went to lane 1 and the others stayed zero. Fixed in PSAL-POSTECH/riscv-isa-sim#4 (released as v1.0.2).

**This PR:**
- `tests/ops/misc/test_widen_dtype.py` -- regression test (int8/int16 + uint8<128 widening; signed/small-unsigned so it is independent of the separate uint8->int8 issue #238).
- Bump the Spike pin v1.0.1 -> v1.0.2 in `thirdparty/github-releases.json`. The base-image pin is `sha256(github-releases.json + Dockerfile.base)`, so `ensure-base` rebuilds the base with the fixed Spike automatically.
- Add the test to the CI allowlist (`pytorchsim_test.yml`).

Verified locally with a Spike built from the v1.0.2 source: all widening cases go FAIL -> PASS (Spike+gem5 allclose).

🤖 Generated with [Claude Code](https://claude.com/claude-code)