### PR TITLE
[Frontend] Per-kernel CPU functional verify (localize first diverging kernel)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,12 @@ export TORCHSIM_DUMP_MLIR_IR=1
 export TORCHSIM_DUMP_LLVM_IR=1
 ```
 
+**To find which op a wrong result first diverges at** (per-kernel CPU cross-check;
+sub-option of functional mode). Set `pytorchsim_functional_verify_per_kernel: 1`
+in the config YAML, clear the codegen cache, and re-run: each compiled kernel's
+output is compared to a CPU golden and the run stops at the first divergent
+kernel, naming the op and offending indices. See `docs/per-kernel-functional-verify.md`.
+
 ## Key environment variables
 
 Read in `PyTorchSimFrontend/extension_config.py`:
@@ -91,6 +97,7 @@ Located under `configs/*.yml`:
 - `icnt_type` (`simple` | `booksim`), `icnt_latency_cycles`, `icnt_freq_mhz`, `icnt_config_path`
 - `l2d_type` (e.g., `datacache`), `l2d_config` (AccelSim-format cache config string)
 - `pytorchsim_functional_mode` (Spike on/off), `pytorchsim_timing_mode`
+- `pytorchsim_functional_verify_per_kernel` (debug: per-kernel CPU cross-check; see `docs/per-kernel-functional-verify.md`)
 - `codegen_mapping_strategy`: `heuristic` | `autotune` | `external-then-heuristic` | `external-then-autotune`
 - `codegen_external_mapping_file` (key `"M_N_K"` → `{TILE_M, TILE_K, TILE_N}` JSON)
 - `codegen_compiler_optimization`: `"all"` | `"none"` | a list from `{fusion, reduction_epilogue, reduction_reduction, prologue, single_batch_conv, multi_tile_conv, subtile}`

--- a/PyTorchSimFrontend/extension_config.py
+++ b/PyTorchSimFrontend/extension_config.py
@@ -57,6 +57,13 @@ def __getattr__(name):
         return config_yaml['pytorchsim_functional_mode']
     if name == "pytorchsim_timing_mode":
         return config_yaml['pytorchsim_timing_mode']
+    # Sub-option of functional mode: per-kernel CPU cross-check. When set (and
+    # functional mode is on), every realized buffer produced by Spike is compared
+    # against a CPU golden to localize the first kernel whose value diverges.
+    # Auto-disabled when functional mode is off (no Spike values to verify).
+    if name == "pytorchsim_functional_verify_per_kernel":
+        return bool(config_yaml.get('pytorchsim_functional_verify_per_kernel', False)) \
+            and bool(config_yaml['pytorchsim_functional_mode'])
 
     # Mapping strategy
     if name == "codegen_mapping_strategy":

--- a/PyTorchSimFrontend/extension_functional_verify.py
+++ b/PyTorchSimFrontend/extension_functional_verify.py
@@ -1,0 +1,160 @@
+"""Per-kernel CPU cross-check for the functional (Spike) path.
+
+This is a sub-option of ``pytorchsim_functional_mode``: enable it with the YAML
+key ``pytorchsim_functional_verify_per_kernel: 1`` (auto-disabled when functional
+mode is off -- there are no Spike values to verify otherwise).
+
+When enabled, the generated wrapper compares every realized buffer (the output of
+each compiled, fused kernel that Spike just produced) against a CPU "golden"
+reference. The golden is computed once per graph execution by running the
+original aten graph (``V.graph.module``) on CPU with the same inputs. The first
+buffer whose value diverges beyond tolerance pinpoints the fused op-cluster that
+injected the error -- the finest granularity observable in a fused pipeline,
+since intermediate aten ops inside a kernel are not separately materialized.
+
+Tolerances (read once at import):
+  TORCHSIM_FUNCTIONAL_VERIFY_RTOL   relative tolerance (default 1e-4)
+  TORCHSIM_FUNCTIONAL_VERIFY_ATOL   absolute tolerance (default 1e-4)
+
+The check raises FunctionalVerifyMismatch at the first divergent buffer
+(stop-at-first), after logging the kernel, originating fx op, offending indices
+and max abs diff.
+
+NOTE: codegen bakes the check calls into the wrapper only when enabled at
+*compile* time. Toggle the option and clear the codegen cache together
+(scripts/clear_codegen_cache.sh), or a cached wrapper without checks is replayed.
+"""
+import os
+
+import torch
+
+from PyTorchSimFrontend import extension_config
+from PyTorchSimFrontend.extension_config import setup_logger
+
+logger = setup_logger(__name__)
+
+RTOL = float(os.environ.get("TORCHSIM_FUNCTIONAL_VERIFY_RTOL", "1e-4"))
+ATOL = float(os.environ.get("TORCHSIM_FUNCTIONAL_VERIFY_ATOL", "1e-4"))
+
+# Codegen-time registry of runnable aten graphs, keyed by an int id baked into
+# the generated wrapper. Persists in-process: the exec'd wrapper imports this
+# very module, so the dict it sees is the one populated during codegen.
+_GRAPHS = {}
+
+# Per-run state, reset by verify_init at the top of each call(args).
+_STATE = {"golden": None, "n_checked": 0, "failed": False}
+
+
+class FunctionalVerifyMismatch(RuntimeError):
+    """Raised at the first kernel buffer that diverges from the CPU golden."""
+
+
+def enabled():
+    """True when functional mode AND the per-kernel verify sub-option are on.
+
+    Read dynamically (the config can change inside a ``with TOGSimulator(...)``
+    block); the config accessor already AND-gates this with functional mode.
+    """
+    try:
+        return bool(extension_config.pytorchsim_functional_verify_per_kernel)
+    except Exception:
+        return False
+
+
+def register_graph(gm):
+    """Register a runnable aten GraphModule, returning an id for the wrapper."""
+    gid = len(_GRAPHS)
+    _GRAPHS[gid] = gm
+    return gid
+
+
+class _GoldenInterpreter(torch.fx.Interpreter):
+    """Run the aten graph on CPU, recording each node's tensor output by name."""
+
+    def __init__(self, gm):
+        super().__init__(gm)
+        self.values = {}
+
+    def run_node(self, n):
+        out = super().run_node(n)
+        if isinstance(out, torch.Tensor):
+            self.values[n.name] = out.detach().to("cpu", torch.float32)
+        return out
+
+
+def _to_cpu(x):
+    return x.detach().cpu() if isinstance(x, torch.Tensor) else x
+
+
+def verify_init(gid, inputs):
+    """Compute the CPU golden for this graph execution (top of call(args))."""
+    _STATE["golden"] = None
+    _STATE["n_checked"] = 0
+    _STATE["failed"] = False
+    gm = _GRAPHS.get(gid)
+    if gm is None:
+        logger.warning("[FuncVerify] no graph registered for id %s", gid)
+        return
+    try:
+        cpu_inputs = [_to_cpu(x) for x in inputs]
+        interp = _GoldenInterpreter(gm)
+        interp.run(*cpu_inputs)
+        _STATE["golden"] = interp.values
+        logger.info("[FuncVerify] golden ready: %d node tensors (rtol=%g atol=%g)",
+                    len(interp.values), RTOL, ATOL)
+    except Exception as e:  # never let the verify shadow break the real run
+        logger.warning("[FuncVerify] golden computation failed (%r); "
+                       "per-kernel verify disabled for this graph", e)
+        _STATE["golden"] = None
+
+
+def verify_check(value, buffer_name, node_name, op):
+    """Compare one realized buffer against its golden; raise on first divergence."""
+    if _STATE["failed"]:
+        return
+    golden = _STATE["golden"]
+    if golden is None or not isinstance(value, torch.Tensor):
+        return
+    ref = golden.get(node_name)
+    if ref is None:
+        return  # no reference captured for this fx node (non-tensor / folded)
+    val = value.detach().to("cpu", torch.float32)
+    if val.shape != ref.shape:
+        if val.numel() != ref.numel():
+            return
+        val = val.reshape(ref.shape)
+
+    _STATE["n_checked"] += 1
+    if torch.allclose(val, ref, rtol=RTOL, atol=ATOL, equal_nan=True):
+        logger.debug("[FuncVerify] PASS  %-14s %-28s %s",
+                     buffer_name, op, tuple(ref.shape))
+        return
+
+    # ---- divergence ----
+    _STATE["failed"] = True
+    diff = (val - ref).abs()
+    tol = ATOL + RTOL * ref.abs()
+    bad = diff > tol
+    n_bad = int(bad.sum())
+    maxd = float(diff.max())
+    idxs = bad.nonzero()
+    first = idxs[0].tolist() if idxs.numel() else None
+    sample = [f"      {tuple(r.tolist())}: npu={val[tuple(r.tolist())].item():.6g}  "
+              f"cpu={ref[tuple(r.tolist())].item():.6g}"
+              for r in idxs[:6]]
+    logger.error(
+        "\n================= PER-KERNEL FUNCTIONAL VERIFY: DIVERGENCE =================\n"
+        " first divergent buffer : %s\n"
+        " originating fx op      : %s   (node '%s')\n"
+        " shape                  : %s\n"
+        " elements over tol      : %d / %d\n"
+        " max abs diff           : %.6g   (rtol=%g atol=%g)\n"
+        " first bad index        : %s\n"
+        " buffers verified OK    : %d\n"
+        " sample mismatches (npu vs cpu):\n%s\n"
+        "===========================================================================",
+        buffer_name, op, node_name, tuple(ref.shape), n_bad, ref.numel(),
+        maxd, RTOL, ATOL, first, _STATE["n_checked"] - 1, "\n".join(sample))
+    raise FunctionalVerifyMismatch(
+        f"[FuncVerify] first divergence at buffer '{buffer_name}' (op {op}): "
+        f"max abs diff {maxd:.6g}, {n_bad}/{ref.numel()} elements over tol")

--- a/PyTorchSimFrontend/mlir/mlir_codegen_backend.py
+++ b/PyTorchSimFrontend/mlir/mlir_codegen_backend.py
@@ -24,6 +24,7 @@ from torch._inductor.utils import (
 )
 from torch.utils._sympy.functions import ModularIndexing, FloorDiv
 from PyTorchSimFrontend import extension_codecache
+from PyTorchSimFrontend import extension_functional_verify as _func_verify
 from . import mlir_common
 from .mlir_common import LoopLevel, LoopNest
 from .mlir_ops import ExtensionOverrides
@@ -103,6 +104,7 @@ class ExtensionWrapperCodegen(wrapper.PythonWrapperCodegen):
                 from PyTorchSimFrontend.extension_config import CONFIG_SRAM_BUFFER_PLAN, setup_logger
                 from Simulator.simulator import TOGSimulator
                 from PyTorchSimFrontend.extension_op import sparse_mm_dummy_stonne_outer
+                from PyTorchSimFrontend import extension_functional_verify as _fverify
                 from torch._inductor.select_algorithm import extern_kernels
 
                 # Configure logger for generated wrapper code
@@ -162,6 +164,16 @@ class ExtensionWrapperCodegen(wrapper.PythonWrapperCodegen):
                 self.prefix.writeline(f"{lhs} = args")
                 self.prefix.writeline("args.clear()")
 
+            # Per-kernel functional verify: register the runnable aten graph and
+            # emit a CPU golden build at the top of call(), passing graph inputs.
+            if _func_verify.enabled():
+                gm = getattr(V.graph, "module", None)
+                if gm is not None:
+                    gid = _func_verify.register_graph(gm)
+                    in_names = list(V.graph.graph_inputs.keys())
+                    self.prefix.writeline(
+                        f"_fverify.verify_init({gid}, [{', '.join(in_names)}])")
+
             self.codegen_inputs()
             self.codegen_input_size_asserts()
             self.codegen_sram_plan_prefix()
@@ -204,6 +216,7 @@ class ExtensionWrapperCodegen(wrapper.PythonWrapperCodegen):
         result = IndentedBuffer()
         # result.splice(self.header)
 
+        self._fverify_seen = set()
         with contextlib.ExitStack() as stack:
             stack.enter_context(self.wrapper_call.indent())
             self.memory_plan_reuse()
@@ -220,6 +233,8 @@ class ExtensionWrapperCodegen(wrapper.PythonWrapperCodegen):
                         line.codegen(self.wrapper_call)
                     elif isinstance(line, wrapper.KernelCallLine):
                         self.wrapper_call.writeline(self.wrap_kernel_call(line.kernel_name, line.call_args))
+                        if _func_verify.enabled():
+                            self._fverify_emit_checks(line.call_args)
                     else:
                         if isinstance(line, wrapper.WrapperLine):
                             line.codegen(self.wrapper_call)
@@ -248,6 +263,37 @@ class ExtensionWrapperCodegen(wrapper.PythonWrapperCodegen):
             result.getvaluewithlinemap(),
             self.kernel_declarations.getvaluewithlinemap(),
         )
+
+    def _fverify_emit_checks(self, call_args):
+        """Emit per-kernel CPU verify calls for this kernel's output buffers.
+
+        A buffer's value is produced by the first kernel that names it (producer
+        precedes consumers in topo order), so we check each bare-identifier buffer
+        arg the first time it is seen -- that occurrence is its output. The buffer
+        is mapped to its originating fx node (op) so the runtime check can compare
+        against the CPU golden keyed by that node.
+        """
+        for a in call_args:
+            if not isinstance(a, str):
+                continue
+            name = a.strip()
+            if not name.isidentifier() or name in self._fverify_seen:
+                continue
+            self._fverify_seen.add(name)
+            if name in V.graph.graph_inputs:
+                continue  # placeholders: golden == input, nothing to verify
+            try:
+                buf = V.graph.get_buffer(name)
+            except Exception:
+                buf = None
+            if buf is None:
+                continue
+            origin = getattr(buf, "origin_node", None)
+            if origin is None:
+                continue
+            op = str(getattr(origin, "target", "?"))
+            self.wrapper_call.writeline(
+                f'_fverify.verify_check({name}, "{name}", "{origin.name}", "{op}")')
 
     def memory_plan(self):
         self.lines = memory_planning.MemoryPlanner(self).plan(self.lines)

--- a/docs/per-kernel-functional-verify.md
+++ b/docs/per-kernel-functional-verify.md
@@ -1,0 +1,111 @@
+# Per-kernel functional verify
+
+A debugging tool that pinpoints the **first compiled kernel** whose simulated
+(Spike) output diverges from a CPU reference. Use it when a whole-model run gives
+a wrong final result and you need to know *which operation* introduced the error,
+instead of only seeing that the final `torch.allclose` failed.
+
+## TL;DR
+
+```yaml
+# in your TOGSim config YAML (e.g. configs/systolic_ws_8x8_c1_simple_noc_tpuv3.yml)
+pytorchsim_functional_mode: 1               # required (this is its parent)
+pytorchsim_functional_verify_per_kernel: 1  # turn the verify on
+```
+
+```bash
+# checks are baked into the wrapper at compile time, so clear the codegen cache
+# whenever you toggle this option (see the "Gotchas" note in CLAUDE.md)
+bash scripts/clear_codegen_cache.sh
+python tests/models/Yolov5/test_yolov5.py
+```
+
+On the first divergent kernel you get, and the run stops there:
+
+```
+================= PER-KERNEL FUNCTIONAL VERIFY: DIVERGENCE =================
+ first divergent buffer : buf1
+ originating fx op      : aten.relu.default   (node 'relu')
+ shape                  : (16, 16)
+ elements over tol      : 90 / 256
+ max abs diff           : 1.43051e-06   (rtol=1e-4 atol=1e-4)
+ first bad index        : [0, 0]
+ buffers verified OK    : 0
+ sample mismatches (npu vs cpu):
+      (0, 0): npu=0.323295  cpu=0.323294
+      ...
+===========================================================================
+```
+
+## Options
+
+| Option | Where | Default | Meaning |
+|---|---|---|---|
+| `pytorchsim_functional_verify_per_kernel` | config YAML | `0` (off) | enable the per-kernel CPU cross-check |
+| `TORCHSIM_FUNCTIONAL_VERIFY_RTOL` | env | `1e-4` | relative tolerance for the compare |
+| `TORCHSIM_FUNCTIONAL_VERIFY_ATOL` | env | `1e-4` | absolute tolerance for the compare |
+
+It is a **sub-option of `pytorchsim_functional_mode`** and is auto-disabled when
+functional mode is off (there are no Spike values to verify otherwise). The
+config accessor AND-gates the two, so setting the key alone with functional mode
+off does nothing.
+
+## How it works
+
+The value of every tensor in a compiled graph comes from Spike running the
+generated kernels (the timing path / TOGSim cannot change tensor values). This
+tool compares those values against a CPU "golden" at the boundary of each
+compiled kernel.
+
+1. **Golden (once per `call(args)`).** At the top of the generated wrapper,
+   `verify_init(gid, [inputs])` looks up the original aten graph
+   (`V.graph.module`, registered at codegen time), **copies the inputs to CPU**,
+   and runs the whole graph on CPU with an `fx.Interpreter` that records every
+   node's output tensor by name. These are the absolute-correct reference values
+   (computed from the original inputs, with no accumulated npu error).
+
+2. **Check (after each kernel).** After a kernel writes its output buffer,
+   `verify_check(buf, "buf", node_name, op)` copies that npu buffer to CPU and
+   `torch.allclose`-compares it to `golden[node_name]`. The buffer is mapped to
+   its originating fx node via `V.graph.get_buffer(name).origin_node`, which is
+   how the report can name the offending op.
+
+3. **Stop at first.** Each buffer is checked once, on its first appearance as a
+   kernel argument (the producer kernel precedes any consumer in topological
+   order). The first buffer that exceeds tolerance is the injection point -- its
+   inputs were still within tolerance -- so the check logs the report and raises
+   `FunctionalVerifyMismatch` immediately.
+
+Comparison granularity is the **fused-cluster output**: Inductor fuses several
+aten ops into one kernel and only the cluster's realized output buffer is
+observable. The check verifies that buffer and names the cluster's output op. For
+example `relu(a @ b + bias)` is one kernel writing one buffer, reported as
+`aten.relu.default`.
+
+## Limitations
+
+- **Granularity is the fused kernel, not the individual aten op.** If the bug is
+  in an op that was fused into the middle of a cluster (e.g. the matmul inside
+  `relu(a@b+bias)`), it is reported at the cluster's output buffer/op (`relu`),
+  not the internal culprit. Ops that get their own kernel (matmul, conv, cat,
+  sdpa, sort, ...) are named precisely.
+- **Requires a codegen-cache clear when toggling**, because the `verify_*` calls
+  are emitted into the wrapper only when the option is on at compile time. A
+  cached wrapper compiled without it will be replayed without checks.
+- **Coverage, not correctness, degrades gracefully.** A buffer with no
+  `origin_node`, a non-tensor, or a name the golden did not capture is silently
+  skipped (fewer checks, never a false alarm). The golden run is wrapped in
+  try/except: if the aten graph fails to run on CPU, checks are disabled for that
+  graph rather than crashing the real run.
+- **Overhead.** The full aten graph is run on CPU once per `call(args)`, and each
+  buffer is copied to CPU for the compare. This is a debugging mode; leave it off
+  for normal runs.
+
+## Code
+
+- `PyTorchSimFrontend/extension_functional_verify.py` -- graph registry, golden
+  interpreter, compare/report (`register_graph`, `verify_init`, `verify_check`).
+- `PyTorchSimFrontend/mlir/mlir_codegen_backend.py` -- injects the calls into the
+  wrapper (`write_prefix`, `generate`, `_fverify_emit_checks`).
+- `PyTorchSimFrontend/extension_config.py` -- reads the YAML key and AND-gates it
+  with `pytorchsim_functional_mode`.


### PR DESCRIPTION
## What

Adds `pytorchsim_functional_verify_per_kernel`, a sub-option of `pytorchsim_functional_mode` that localizes the first compiled kernel whose Spike output diverges from a CPU reference. Today a wrong model output only shows up as a failed final `torch.allclose`; this pins down which op introduced it.

## How to enable

```yaml
pytorchsim_functional_mode: 1               # parent (required)
pytorchsim_functional_verify_per_kernel: 1  # turn the per-kernel check on
```
- Auto-disabled when functional mode is off (no Spike values to verify); AND-gated in `extension_config`.
- Tolerances via `TORCHSIM_FUNCTIONAL_VERIFY_RTOL` / `_ATOL` (default 1e-4).
- Checks are baked into the wrapper at compile time, so clear the codegen cache when toggling.

## Mechanism

- At the top of the generated `call(args)`, `verify_init` runs the original aten graph (`V.graph.module`) on CPU with the same inputs via an `fx.Interpreter`, recording each node's output (the golden).
- After each kernel, `verify_check` compares that realized buffer (CPU copy) against `golden[origin_node]`, mapped via `V.graph.get_buffer(name).origin_node`.
- First buffer over tolerance -> logs kernel / fx op / offending indices / max abs diff, then raises `FunctionalVerifyMismatch` (stop-at-first). Granularity is the fused-cluster output. Op-agnostic; no per-op special casing.

See `docs/per-kernel-functional-verify.md`.

## Validation

- No false positives: `tests/ops/view/test_cat.py` all pass; a matmul+relu demo passes at default tol and correctly fires at atol=rtol=0 on the real ~1e-6 fp difference.
- Used it on the yolov5 8x8 mismatch: it pinpointed the first divergence at `cat_3` (the Detect-head 3-scale concat), inputs clean. That led to the root cause being a Spike uninitialized DMA-buffer bug (fixed upstream by the zero-init commit / spike v1.0.3), not a codegen bug. Re-running with the fixed spike: full model passes.

## Scope

Additive only: new `extension_functional_verify.py`, three injection hooks in `mlir_codegen_backend.py`, one config key in `extension_config.py`, a doc, and CLAUDE.md pointers. No behavior change when the option is off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)