### PR TITLE
[Frontend] Budget fused-prologue spad buffers in BMM tile selection

### DIFF
--- a/PyTorchSimFrontend/mlir/mlir_bmm_template.py
+++ b/PyTorchSimFrontend/mlir/mlir_bmm_template.py
@@ -165,10 +165,10 @@ class MLIRBMMTemplate(MLIRTemplate):
                prologue_nodes: Optional[List[IRNode]] = None,
                tile_info = None,
                **kwargs):
-        X, W, Y, Bias, W_tensor, X_tensor, B, M, N, K, n_extra_node, n_prologue_node = self.extract_info(template_buffer_node, epilogue_nodes, prologue_nodes)
+        X, W, Y, Bias, W_tensor, X_tensor, B, M, N, K, n_extra_node, n_prologue_node, n_extra_read = self.extract_info(template_buffer_node, epilogue_nodes, prologue_nodes)
         precision_bytes = mlir_common.get_dtype_nbytes(X.get_dtype())
         if tile_info is None:
-            TILE_M, TILE_N, TILE_K, SUB_TILE_M, SUB_TILE_N, SUB_TILE_K = self.select_tile(kernel, M, N, K, n_extra_node, 0, n_prologue_node, precision_bytes)[0]
+            TILE_M, TILE_N, TILE_K, SUB_TILE_M, SUB_TILE_N, SUB_TILE_K = self.select_tile(kernel, M, N, K, n_extra_node, n_extra_read, n_prologue_node, precision_bytes)[0]
         else:
             TILE_M, TILE_N, TILE_K, SUB_TILE_M, SUB_TILE_N, SUB_TILE_K = tile_info
 
@@ -342,7 +342,38 @@ class MLIRBMMTemplate(MLIRTemplate):
         # Select tile size
         n_extra_node = len(epilogue_nodes) if epilogue_nodes is not None else 0
         n_prologue_node = len(prologue_nodes) if prologue_nodes is not None else 0
-        return X,W,Y,Bias,W_tensor,X_tensor,B,M,N,K,n_extra_node, n_prologue_node
+        n_extra_read = self.count_prologue_extra_buffers(prologue_nodes)
+        return X,W,Y,Bias,W_tensor,X_tensor,B,M,N,K,n_extra_node, n_prologue_node, n_extra_read
+
+    def count_prologue_extra_buffers(self, prologue_nodes):
+        # Each prologue node reuses the matmul-operand spad buffer for its one
+        # "main" input (the read whose numel matches the node, MVIN'd in place)
+        # and for its single output; see codegen_template_code. Every other read
+        # (e.g. the softmax max/sum broadcast operands) is laid out as its own
+        # disjoint output-tile-sized .spad global, so it must be budgeted in tile
+        # selection or the emitted kernel overflows spad/2 (mirrors the epilogue
+        # n_extra_read accounting in the GEMM template).
+        if not prologue_nodes:
+            return 0
+        from functools import reduce
+        import operator
+        from torch._inductor.virtualized import V
+        buf_dict = {val.name: val for val in V.graph.buffers}
+        buf_dict.update(V.graph.graph_inputs)
+        prologue_outputs = {list(node.read_writes.writes)[0].name for node in prologue_nodes}
+        extra = set()
+        for node in prologue_nodes:
+            reads = sorted(i.name for i in node.read_writes.reads)
+            main_input = None
+            for candidate_read in reads:
+                if candidate_read in buf_dict and \
+                   reduce(operator.mul, buf_dict[candidate_read].get_size(), 1) == node.node.get_numel():
+                    main_input = candidate_read
+                    break
+            for r in reads:
+                if r != main_input and r not in prologue_outputs:
+                    extra.add(r)
+        return len(extra)
 
     def get_tile_candidates(self,
                kernel: MLIRTemplateKernel,
@@ -350,12 +381,18 @@ class MLIRBMMTemplate(MLIRTemplate):
                epilogue_nodes: Optional[List[IRNode]] = None,
                prologue_nodes: Optional[List[IRNode]] = None,
                **kwargs):
-        X, W, Y, Bias, W_tensor, X_tensor, B, M, N, K, n_extra_node, n_prologue_node = self.extract_info(template_buffer_node, epilogue_nodes, prologue_nodes)
+        X, W, Y, Bias, W_tensor, X_tensor, B, M, N, K, n_extra_node, n_prologue_node, n_extra_read = self.extract_info(template_buffer_node, epilogue_nodes, prologue_nodes)
         precision_bytes = mlir_common.get_dtype_nbytes(X.get_dtype())
-        return self.select_tile(kernel, M, N, K, n_extra_node, 0, n_prologue_node, precision_bytes)
+        return self.select_tile(kernel, M, N, K, n_extra_node, n_extra_read, n_prologue_node, precision_bytes)
 
     def select_tile(self, kernel, M, N, K, n_extra_node, n_extra_read, n_prologue_node, precision_bytes):
-        tile_candidates = kernel.gemm_combination_mapping(M, N, K, n_extra_node=n_extra_node, precision_bytes=precision_bytes)
+        # Budget the prologue's extra-read .spad globals (e.g. the softmax max/sum
+        # operands) so the chosen tile actually fits spad/2. They are laid out at the
+        # produced-operand (weight) tile size, so account for them as weight-tile
+        # buffers; the prologue's main input reuses the matmul-operand buffer.
+        tile_candidates = kernel.gemm_combination_mapping(
+            M, N, K, n_extra_node=n_extra_node, n_prologue_extra_read=n_extra_read,
+            precision_bytes=precision_bytes)
         for idx, (TILE_M, TILE_N, TILE_K) in enumerate(tile_candidates):
             SUB_TILE_M = TILE_M if (TILE_M < kernel.vector_lane) or n_prologue_node else kernel.vector_lane
             SUB_TILE_N = TILE_N # if (TILE_N < kernel.vector_lane) or prologue_nodes else kernel.vector_lane

--- a/PyTorchSimFrontend/mlir/mlir_bmm_template.py
+++ b/PyTorchSimFrontend/mlir/mlir_bmm_template.py
@@ -346,13 +346,7 @@ class MLIRBMMTemplate(MLIRTemplate):
         return X,W,Y,Bias,W_tensor,X_tensor,B,M,N,K,n_extra_node, n_prologue_node, n_extra_read
 
     def count_prologue_extra_buffers(self, prologue_nodes):
-        # Each prologue node reuses the matmul-operand spad buffer for its one
-        # "main" input (the read whose numel matches the node, MVIN'd in place)
-        # and for its single output; see codegen_template_code. Every other read
-        # (e.g. the softmax max/sum broadcast operands) is laid out as its own
-        # disjoint output-tile-sized .spad global, so it must be budgeted in tile
-        # selection or the emitted kernel overflows spad/2 (mirrors the epilogue
-        # n_extra_read accounting in the GEMM template).
+        # Count prologue reads needing their own .spad global: the numel-matching main input reuses the matmul-operand buffer, every other read (e.g. softmax max/sum) gets a disjoint one (see codegen_template_code).
         if not prologue_nodes:
             return 0
         from functools import reduce
@@ -386,10 +380,7 @@ class MLIRBMMTemplate(MLIRTemplate):
         return self.select_tile(kernel, M, N, K, n_extra_node, n_extra_read, n_prologue_node, precision_bytes)
 
     def select_tile(self, kernel, M, N, K, n_extra_node, n_extra_read, n_prologue_node, precision_bytes):
-        # Budget the prologue's extra-read .spad globals (e.g. the softmax max/sum
-        # operands) so the chosen tile actually fits spad/2. They are laid out at the
-        # produced-operand (weight) tile size, so account for them as weight-tile
-        # buffers; the prologue's main input reuses the matmul-operand buffer.
+        # Budget the prologue extra-read globals as weight-tile buffers (their emitted size) so the chosen tile fits spad/2.
         tile_candidates = kernel.gemm_combination_mapping(
             M, N, K, n_extra_node=n_extra_node, n_prologue_extra_read=n_extra_read,
             precision_bytes=precision_bytes)

--- a/PyTorchSimFrontend/mlir/mlir_template.py
+++ b/PyTorchSimFrontend/mlir/mlir_template.py
@@ -204,7 +204,7 @@ class MLIRTemplateKernel(MLIRKernel, BaseMLIRHardwareInfo):
 
         return inner_I, inner_J, inner_K
 
-    def gemm_combination_mapping(self, M, N, K, n_extra_node=0, n_prologue_node=0, pad_k=True, min_tile=False, is_conv=False, precision_bytes=4):
+    def gemm_combination_mapping(self, M, N, K, n_extra_node=0, n_prologue_node=0, n_prologue_extra_read=0, pad_k=True, min_tile=False, is_conv=False, precision_bytes=4):
         tile_candidates = []
         spad_size_per_lane = self.spad_info["spad_size"]
         spad_size = spad_size_per_lane * self.vector_lane
@@ -232,8 +232,8 @@ class MLIRTemplateKernel(MLIRKernel, BaseMLIRHardwareInfo):
                 tile_M = i * self.vector_lane if M > self.vector_lane else M_padded
                 for j in tile_N_range:
                     tile_N = j * self.vector_lane if N > self.vector_lane else N_padded
-                    used_spad_size = (tile_M * tile_K * (1 + n_prologue_node) + tile_K * tile_N + tile_M * tile_N * (1 + n_extra_node)) * precision_bytes
-                    weight_size_per_lane = self.get_spad_size_per_lane(tile_K, tile_N)
+                    used_spad_size = (tile_M * tile_K * (1 + n_prologue_node) + tile_K * tile_N * (1 + n_prologue_extra_read) + tile_M * tile_N * (1 + n_extra_node)) * precision_bytes
+                    weight_size_per_lane = self.get_spad_size_per_lane(tile_K, tile_N) * (1 + n_prologue_extra_read)
                     input_size_per_lane = self.get_spad_size_per_lane(tile_M * (1 + n_prologue_node), tile_K)
                     output_size_per_lane = self.get_spad_size_per_lane(tile_M * (1 + n_extra_node), tile_N)
                     used_spad_size_per_lane = (weight_size_per_lane + input_size_per_lane + output_size_per_lane) * precision_bytes
@@ -258,8 +258,8 @@ class MLIRTemplateKernel(MLIRKernel, BaseMLIRHardwareInfo):
                 tile_M = i * self.vector_lane if M > self.vector_lane else M_padded
                 for j in tile_N_range:
                     tile_N = j * self.vector_lane if N > self.vector_lane else N_padded
-                    used_spad_size = (tile_M * tile_K * (1 + n_prologue_node) + tile_K * tile_N + tile_M * tile_N * (1 + n_extra_node)) * precision_bytes
-                    weight_size_per_lane = self.get_spad_size_per_lane(tile_K, tile_N)
+                    used_spad_size = (tile_M * tile_K * (1 + n_prologue_node) + tile_K * tile_N * (1 + n_prologue_extra_read) + tile_M * tile_N * (1 + n_extra_node)) * precision_bytes
+                    weight_size_per_lane = self.get_spad_size_per_lane(tile_K, tile_N) * (1 + n_prologue_extra_read)
                     input_size_per_lane = self.get_spad_size_per_lane(tile_M * (1 + n_prologue_node), tile_K)
                     output_size_per_lane = self.get_spad_size_per_lane(tile_M * (1 + n_extra_node), tile_N)
                     used_spad_size_per_lane = (weight_size_per_lane + input_size_per_lane + output_size_per_lane) * precision_bytes


### PR DESCRIPTION
## Problem

wrapper2 CI (`systolic_ws_32x32`, 32 lanes x 32 KB/lane spad -> 16 KB/lane spad/2 budget) failed `test_transformer` with `SpadOverflowError` at `mlir_kernel_4`, while wrapper1 (128x128, 64 KB/lane budget) passed. [Failing job](https://github.com/PSAL-POSTECH/PyTorchSim/actions/runs/28174587855/job/83451306526).

`mlir_kernel_4` is the attention batched matmul `value^T @ softmax(scores)` with the **softmax fused as a prologue**. The emitted kernel lays out 5 `.spad` globals:

| buffer | shape | per-lane |
|---|---|---|
| X_spad | 64x64 | 128 |
| W_spad | 64x512 | 1024 |
| Y_spad | 64x512 | 1024 |
| **buf3_spad** (softmax max) | 64x512 | 1024 |
| **buf4_spad** (softmax sum) | 64x512 | 1024 |

Measured footprint = **16896 B/lane** vs budget **16384 B/lane** -> overflow by exactly 512 B.

## Root cause

`MLIRBMMTemplate.select_tile` passed only `n_extra_node` to `gemm_combination_mapping` and dropped the prologue's extra-read operands, so the softmax-fused matmul was budgeted as a bare BMM. The two broadcast operands (max/sum) are each laid out as their own disjoint weight-tile-sized `.spad` global, but tile selection counted neither -> it picked `TILE_N=512`, which does not fit spad/2, and the heuristic path has no tile-shrink fallback. The 128x128 config had enough slack to hide it.

This is the same class of bug as the epilogue `n_extra_read` gap fixed for the GEMM template in f05ac8a3, now on the BMM prologue path.

## Fix

- Add an `n_prologue_extra_read` knob to `gemm_combination_mapping` that charges each extra prologue-read operand as one weight-tile-sized (`TILE_K x TILE_N`) `.spad` buffer -- matching what the codegen emits. Defaults to 0, so GEMM and conv callers are unchanged.
- `MLIRBMMTemplate` counts those operands the same way codegen does: the one numel-matching main input reuses the matmul-operand buffer; every other read gets its own global.

With the honest budget, tile selection rejects `TILE_N=512` (16896 B/lane) and picks a fitting tile (8704 B/lane).

## Validation

- wrapper2 (`systolic_ws_32x32`) `test_transformer` now passes the full Spike + `allclose` functional check (`|Encoder Block Forwrad Test Passed|`).
- `test_bmm` on the default 128x128 config still passes (no regression on the plain-BMM / shared-mapping path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)