### PR TITLE
[CI] Run test_scheduler on github-hosted with extra disk

### DIFF
--- a/.github/workflows/pytorchsim_test.yml
+++ b/.github/workflows/pytorchsim_test.yml
@@ -637,6 +637,16 @@ jobs:
     name: Run test_scheduler
     runs-on: ubuntu-latest
     steps:
+      - name: Free up disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: false
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -647,8 +657,17 @@ jobs:
       - name: Run test_scheduler.py
         run: |
           echo "Running test_scheduler.py"
+          # test_scheduler compiles resnet18 + EncoderBlock and launches each
+          # twice, so per-kernel RISC-V ELFs, objdump dumps and gem5 m5out dirs
+          # accumulate and overflow the small github-hosted root volume.
+          # Redirect those artifacts to the larger /mnt scratch disk (~70G).
+          sudo mkdir -p /mnt/togout /mnt/togtmp
+          sudo chmod 777 /mnt/togout /mnt/togtmp
           docker run --rm \
             -e TOGSIM_CONFIG="${{ inputs.togsim_config }}" \
+            -e TMPDIR=/tmp \
+            -v /mnt/togout:/workspace/PyTorchSim/outputs \
+            -v /mnt/togtmp:/tmp \
             ${{ inputs.image_name }} python3 PyTorchSim/tests/system/test_scheduler.py
 
   test_llama:


### PR DESCRIPTION
## Problem

`test_scheduler` fails on the github-hosted runner with:

```
riscv64-unknown-elf/bin/ld: final link failed: No space left on device
```

The test compiles `resnet18` (channels_last) and `EncoderBlock(768, 12)` and `launch_model`s each model twice. Every unique compiled kernel leaves artifacts behind within the single run:

- a statically-linked RISC-V ELF (gem5 + spike target, newlib static -> several MB each)
- `binary.dump` from `objdump -d` (full disassembly incl. libc)
- gem5 `m5out` dirs and spike arg dumps

resnet18 alone has 20+ conv/bn/relu kernels, so these accumulate past the ~14G github-hosted root volume and the RISC-V link step runs out of space. Single-op tests stay small enough to pass.

## Fix

Scope changes to the `test_scheduler` job only:

1. `jlumbroso/free-disk-space` step removes preinstalled tool caches (~25G recovered).
2. Mount the larger `/mnt` scratch disk (~70G) over the container's `outputs/` and `/tmp` so accumulated artifacts no longer land on root.

No test semantics or simulator behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)