### PR TITLE
[TOGSim] Fix use-after-erase in the zero-cycle COMP skip path

### DIFF
--- a/TOGSim/src/Core.cc
+++ b/TOGSim/src/Core.cc
@@ -398,7 +398,9 @@ void Core::cycle() {
               inst->finish_instruction();
               static_cast<Tile*>(inst->get_owner())->inc_finished_inst();
               _stat_tot_skipped_inst.at(static_cast<size_t>(inst->get_opcode()))++;
-              instructions.erase(it);
+              it = instructions.erase(it);   // erase returns the next iterator; the
+              continue;                      // old code fell through to it++ on the
+                                             // erased (invalidated) iterator -> UB
             } else {
               core_trace_log::trace_instruction_line(_core_cycle,
                                                        _id,


### PR DESCRIPTION
## Bug

In `Core::cycle()`'s issue scan, a `COMP` with `compute_cycle == 0` finishes inline and calls `instructions.erase(it)`, but does **not** set `issued` or `break` -- so control falls through to the `it++` at the end of the loop body, incrementing the `std::list` iterator that `erase()` just invalidated:

```cpp
if (inst->get_compute_cycle() == 0) {
  inst->finish_instruction();
  ...
  instructions.erase(it);   // node freed, it invalidated
}                           // no `issued = true`, no break
...
if (issued) { ...; break; } // issued == false here
it++;                       // UB: it++ on the erased iterator
```

`std::list::erase` deallocates the node, so the subsequent `it++` reads a freed node's `next` pointer -- undefined behavior. It usually limps along (the freed node's next is briefly intact), but under a different allocator / sanitizer / build it can crash or skip-or-duplicate the remaining ready instructions in the tile, corrupting issue order.

Pre-existing (not introduced by any recent change); the zero-cycle COMP path is reached e.g. when a sparse `MEMORY_BAR` zeroes its matmul consumers' `compute_cycle`.

## Fix

Use the iterator `erase()` returns and `continue` -- the standard erase-in-loop idiom. No behavior change on the path that happened to work; it just removes the UB. Builds clean; `test_matmul` passes (11/11) on the 8x8 config.