### PR TITLE
[Model] Enable SwinV2 shifted-window attention (issue #251)

### DIFF
--- a/.github/workflows/pytorchsim_test.yml
+++ b/.github/workflows/pytorchsim_test.yml
@@ -18,8 +18,9 @@ on:
 
 # Runner policy: the CPU-only CI image is small enough to pull on GitHub-hosted
 # runners, so op and model tests run on ubuntu-latest. The memory/time-intensive
-# jobs stay on self-hosted: test_deepseek (largest model), test_diffusion (UNet2D
-# simulation OOMs the hosted runner), and test_accuracy (accuracy + speedup).
+# jobs stay on self-hosted: test_deepseek (largest model), test_swinv2 (SwinV2
+# shifted-window backbone), test_diffusion (UNet2D simulation OOMs the hosted
+# runner), and test_accuracy (accuracy + speedup).
 jobs:
   test_add:
     name: Run test_add.py
@@ -724,6 +725,26 @@ jobs:
           docker run --rm \
             -e TOGSIM_CONFIG="${{ inputs.togsim_config }}" \
             ${{ inputs.image_name }} python3 PyTorchSim/tests/models/DeepSeek/test_deepseek_v3_base.py
+
+  test_swinv2:
+    name: Run test_swinv2.py
+    # SwinV2 backbone (shifted-window attention) is heavy; keep it on a
+    # self-hosted runner like the other model tests.
+    runs-on: self-hosted
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run test_swinv2.py
+        run: |
+          echo "Running test_swinv2.py"
+          docker run --rm \
+            -e TOGSIM_CONFIG="${{ inputs.togsim_config }}" \
+            ${{ inputs.image_name }} python3 PyTorchSim/tests/models/test_swinv2.py
 
   test_eager:
     name: Run test_eager.py

--- a/PyTorchSimFrontend/mlir/axis_split.py
+++ b/PyTorchSimFrontend/mlir/axis_split.py
@@ -29,6 +29,77 @@ def _as_int(x):
         return None
 
 
+def _as_digit(expr):
+    """If ``expr`` is a single-variable *digit extractor* -- any nesting of FloorDiv /
+    ModularIndexing whose innermost argument is one symbol ``v`` -- return ``(v, div, mod)``
+    meaning ``(v // div) % mod`` (``mod is None`` -> a pure ``v // div``). Otherwise None.
+
+    Every such nesting collapses to a single (div, mod) by composing divisors, from four
+    algebraic identities (v >= 0, all constants positive integers):
+        FloorDiv(v//a,        b)      = v // (a*b)
+        FloorDiv((v//a)%m,    b)      = (v // (a*b)) % (m//b)      if b   | m
+        ModularIndexing(v//a,    b,m2)= (v // (a*b)) % m2
+        ModularIndexing((v//a)%m, b,m2)= (v // (a*b)) % m2         if b*m2| m
+    The divisibility guards make every rewrite provably equality-preserving. A multi-
+    variable inner argument (e.g. torch.roll's v+shift) is not a digit extractor -> None.
+    """
+    if isinstance(expr, sympy.Symbol):
+        return (expr, 1, None)
+    if isinstance(expr, FloorDiv):
+        inner, b = expr.args
+        b, e = _as_int(b), _as_digit(expr.args[0])
+        if e is None or b is None:
+            return None
+        v, a, m = e
+        if m is None:
+            return (v, a * b, None)
+        if m % b == 0:
+            return (v, a * b, m // b)
+        return None
+    if isinstance(expr, ModularIndexing):
+        inner, b, m2 = expr.args
+        b, m2, e = _as_int(b), _as_int(m2), _as_digit(expr.args[0])
+        if e is None or b is None or m2 is None:
+            return None
+        v, a, m = e
+        if m is None:
+            return (v, a * b, m2)
+        if m % (b * m2) == 0:
+            return (v, a * b, m2)
+        return None
+    return None
+
+
+def _rebuild_digit(v, a, m):
+    """Canonical single-level form of ``(v // a) % m``."""
+    x = v if a == 1 else FloorDiv(v, a)
+    return x if m is None else ModularIndexing(v, a, m)
+
+
+def flatten_nested_floormod(expr):
+    """Collapse nested single-variable FloorDiv/ModularIndexing to one level.
+
+    A composition of aligned reshapes on one iteration variable leaves a nested index like
+    ModularIndexing(ModularIndexing(p, 1, 64), 1, 8) that neither sympy nor
+    simplify_with_ranges reduces, so collect_boundaries skips its cut points (the inner base
+    is not a bare var) and the affine-only DMA check later rejects it. Rewriting each nested
+    digit extractor to its single-level (v // A) % M form (via _as_digit) exposes those cut
+    points to axis-split. General and pattern-free -- no per-shape special cases.
+    """
+    try:
+        atoms = expr.atoms(FloorDiv, ModularIndexing)
+    except AttributeError:
+        return expr
+    replace = {}
+    for atom in atoms:
+        e = _as_digit(atom)
+        if e is not None:
+            canon = _rebuild_digit(*e)
+            if canon != atom:
+                replace[atom] = canon
+    return expr.xreplace(replace) if replace else expr
+
+
 def collect_boundaries(exprs, var_to_axis, var_ranges):
     """{axis_index: set(boundary cut points)} for the given index expressions.
 
@@ -39,6 +110,7 @@ def collect_boundaries(exprs, var_to_axis, var_ranges):
     import collections
     bset = collections.defaultdict(set)
     for expr in exprs:
+        expr = flatten_nested_floormod(expr)   # nested digit extractors -> single level
         for fd in expr.atoms(FloorDiv):
             base, div = fd.args
             k = _as_int(div)
@@ -196,6 +268,7 @@ def _fold_with_ranges(expr, var_ranges):
     Iterated to a fixpoint (folding a mod can expose a foldable floor).
     """
     from torch.utils._sympy.value_ranges import bound_sympy, ValueRanges
+    expr = flatten_nested_floormod(expr)   # collapse any residual single-var nested digit
     ranges = {}
     for v, sz in var_ranges.items():
         e = _as_int(sz)

--- a/PyTorchSimFrontend/mlir/mlir_codegen_backend.py
+++ b/PyTorchSimFrontend/mlir/mlir_codegen_backend.py
@@ -120,6 +120,7 @@ class ExtensionWrapperCodegen(wrapper.PythonWrapperCodegen):
                 inductor_ops = torch.ops.inductor
                 assert_size_stride = torch._C._dynamo.guards.assert_size_stride
                 assert_alignment = torch._C._dynamo.guards.assert_alignment
+                empty_strided_cpu = torch._C._dynamo.guards._empty_strided_cpu
                 alloc_from_pool = torch.ops.inductor._alloc_from_pool
                 reinterpret_tensor = torch.ops.inductor._reinterpret_tensor
                 custom_async_compile = CustomAsyncCompile()

--- a/PyTorchSimFrontend/mlir/mlir_codegen_backend.py
+++ b/PyTorchSimFrontend/mlir/mlir_codegen_backend.py
@@ -44,10 +44,16 @@ def reduction_init(reduction_type, dtype):
         return float(0) if dtype.is_floating_point else int(0)
     if reduction_type == "prod":
         return float(1) if dtype.is_floating_point else int(1)
+    # Integer reductions cannot use a +/-inf identity (invalid as an int constant and
+    # overflows torch.tensor(inf, dtype=int)); use the dtype's representable extreme.
     if reduction_type in {"max", "argmax"}:
-        return "-inf"
+        if dtype.is_floating_point:
+            return "-inf"
+        return 0 if dtype is torch.bool else torch.iinfo(dtype).min
     if reduction_type in {"min", "argmin"}:
-        return "inf"
+        if dtype.is_floating_point:
+            return "inf"
+        return 1 if dtype is torch.bool else torch.iinfo(dtype).max
     if reduction_type in {"welford_reduce"}:
         return f"0.0"
     raise AssertionError(reduction_type)

--- a/PyTorchSimFrontend/mlir/mlir_codegen_backend.py
+++ b/PyTorchSimFrontend/mlir/mlir_codegen_backend.py
@@ -1330,16 +1330,23 @@ class MLIRKernel(mlir_common.BaseMLIRKernel):
                 local_tile_desc.set_tile_size([kg_tile_desc.get_dim_size(dim) for dim in local_dims])
                 local_tile_desc.vmap.vlane_split_axis = local_vlane_split_axis
                 local_tile_desc.vmap.vlane_stride = kg_tile_desc.vmap.vlane_stride
-        # Case 4. Tile is 4-D tile (e.g., Convolution epilogue)
-        elif len(local_dims) == 4:
-            is_reduction = self.reduction_depth < 3 and not store_reduction
-            if is_reduction:
-                raise NotImplementedError("Currently not implemented... ;)")
-            local_tile_desc.set_tile_size([kg_tile_desc.get_dim_size(dim) for dim in local_dims])
-            local_tile_desc.vmap.vlane_split_axis = local_vlane_split_axis
-            local_tile_desc.vmap.vlane_stride = kg_tile_desc.vmap.vlane_stride
+        # Case 4+. Tile is 4-D or higher (Convolution epilogue, gathered attention bias,
+        # var_mean over an axis whose batch dims got split into many loop vars).
         else:
-            local_tile_desc.set_tile_size([kg_tile_desc.get_dim_size(dim) for dim in local_dims])
+            # A reduction tile carries the reduction axis (loop dims >= reduction_depth).
+            # It must place that axis-group OUTERMOST in the per-lane layout so the 2-D
+            # [reduction | batch] multi_reduction reduces the reduction axis (not a batch
+            # axis). Same reorder the 3-D case does, generalized to any rank: an indirect
+            # attention-bias gather blocks a head*query dim-merge and leaves head in-lane,
+            # and a var_mean's token axis can split into several batch loop vars -- both
+            # leave a batch axis inner-to-reduction under the default row-major order.
+            is_reduction = any(d >= self.reduction_depth for d in local_dims) and not store_reduction
+            if is_reduction:
+                r = self.get_nr_rdim()
+                axis_order = list(range(r, len(local_dims))) + list(range(r - 1, -1, -1))
+                local_tile_desc.set_tile_size([kg_tile_desc.get_dim_size(dim) for dim in local_dims], axis_order)
+            else:
+                local_tile_desc.set_tile_size([kg_tile_desc.get_dim_size(dim) for dim in local_dims])
             local_tile_desc.vmap.vlane_split_axis = local_vlane_split_axis
             local_tile_desc.vmap.vlane_stride = kg_tile_desc.vmap.vlane_stride
 

--- a/PyTorchSimFrontend/mlir/mlir_decomposition.py
+++ b/PyTorchSimFrontend/mlir/mlir_decomposition.py
@@ -372,3 +372,55 @@ def decompose_native_multi_head_attention(
         return output, attn_weights_mean
     else:
         return (output, None)
+
+
+# Lower roll ourselves as narrow + cat, then REALIZE the result. roll has no Inductor lowering; it
+# is decomposed (torch's default is index_select(fmod(...)), i.e. a modular gather the affine-only
+# DMA cannot express). Even our narrow+cat rewrite lets the slice offset fuse into a downstream
+# modular reshape, re-creating a shifted index like (p+60)%8. copy_input forces a hard buffer
+# boundary so the consumer reads a plain affine index -- a plain .contiguous()/clone is inlined by
+# Inductor and does NOT create the boundary. Remove roll from the decomp table so it reaches this
+# lowering instead of being decomposed first.
+from torch._inductor.decomposition import decompositions as _inductor_decompositions
+from torch._inductor import lowering as _ind_lowering
+from torch._inductor import ir as _ind_ir
+
+_inductor_decompositions.pop(aten.roll.default, None)
+
+
+def _roll_lowering(x, shifts, dims=()):
+    if not isinstance(shifts, (list, tuple)):
+        shifts = (shifts,)
+    if not isinstance(dims, (list, tuple)):
+        dims = (dims,)
+    slice_l = _ind_lowering.lowerings[aten.slice.Tensor]
+    cat_l = _ind_lowering.lowerings[aten.cat.default]
+    view_l = _ind_lowering.lowerings[aten.view.default]
+
+    # Realize the INPUT: roll's producer is often a reshaped view (e.g. swinv2's window_reverse),
+    # and our slice's offset would otherwise fuse into that reshape's modular index. Reading a
+    # materialized buffer makes each slice a plain contiguous read.
+    x = _ind_ir.ExternKernel.copy_input(x)
+
+    def roll_dim(t, shift, dim):
+        n = int(t.get_size()[dim])
+        s = int(shift) % n
+        if s == 0:
+            return t
+        front = slice_l(t, dim, n - s, n)          # narrow(t, dim, n-s, s)
+        back = slice_l(t, dim, 0, n - s)
+        return cat_l([front, back], dim)
+
+    if len(dims) == 0:
+        numel = 1
+        for d in x.get_size():
+            numel *= int(d)
+        result = view_l(roll_dim(view_l(x, [numel]), shifts[0], 0), list(x.get_size()))
+    else:
+        result = x
+        for shift, dim in zip(shifts, dims):
+            result = roll_dim(result, shift, dim)
+    return _ind_ir.ExternKernel.copy_input(result)
+
+
+_ind_lowering.lowerings[aten.roll.default] = _roll_lowering

--- a/PyTorchSimFrontend/mlir/mlir_ops.py
+++ b/PyTorchSimFrontend/mlir/mlir_ops.py
@@ -13,10 +13,15 @@ def reduction_combine_vec(reduction_type, vector_value, init_value, axis, shape,
         return f"vector.multi_reduction <add>, %{vector_value}, %{init_value} [{axis}] : {shape} to {reduced_shape}"
     if reduction_type == "prod":
         return f"vector.multi_reduction <mul>, %{vector_value}, %{init_value} [{axis}] : {shape} to {reduced_shape}"
+    # element type of the reduced vector (e.g. "vector<8x2xi64>" -> "i64"); int max/min use
+    # the signed-integer reduction kinds, not the float ones (maximumf/minimumf reject ints).
+    _is_int = shape.rsplit("x", 1)[-1].rstrip(">").strip().startswith("i")
     if reduction_type == "max":
-        return f"vector.multi_reduction <maximumf>, %{vector_value}, %{init_value} [{axis}] : {shape} to {reduced_shape}"
+        kind = "maxsi" if _is_int else "maximumf"
+        return f"vector.multi_reduction <{kind}>, %{vector_value}, %{init_value} [{axis}] : {shape} to {reduced_shape}"
     if reduction_type == "min":
-        return f"vector.multi_reduction <minimumf>, %{vector_value}, %{init_value} [{axis}] : {shape} to {reduced_shape}"
+        kind = "minsi" if _is_int else "minimumf"
+        return f"vector.multi_reduction <{kind}>, %{vector_value}, %{init_value} [{axis}] : {shape} to {reduced_shape}"
     if reduction_type == "any":
         return f"vector.multi_reduction <or>, %{vector_value}, %{init_value} [{axis}] : {shape} to {reduced_shape}"
     raise AssertionError(reduction_type)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ PyTorchSim **supports**:
 | Stable-diffusion v1 | 🤗 | ✅ |  |
 | Llama 2/3 | 🤗 | ✅ | `tests/models/Llama/` (blocks & decode-style paths) |
 | DeepSeek-V3 (base) | 🤗 | ✅ | `tests/models/DeepSeek/` — several ops(e.g., gate ops) are not cycle-modeled |
+| SwinV2 | 🤗 | ✅ | `tests/models/test_swinv2.py` (shifted-window attention) |
 | Llama-4 | 🤗 | ⏳ | In development |
 | Broader model support | — | ⏳ | In development |
 <!-- ## Requirements

--- a/tests/models/test_swinv2.py
+++ b/tests/models/test_swinv2.py
@@ -1,0 +1,69 @@
+import argparse
+import os
+import sys
+
+import torch
+from transformers import Swinv2Config, Swinv2Model
+
+sys.path.insert(0, os.path.join(os.environ.get("TORCHSIM_DIR", default="/workspace/PyTorchSim"), "tests"))
+from _pytorchsim_utils import test_result
+
+
+def _init_weights(m):
+    if isinstance(m, torch.nn.Linear):
+        torch.nn.init.normal_(m.weight, mean=0.0, std=0.02)
+        if m.bias is not None:
+            torch.nn.init.zeros_(m.bias)
+    elif isinstance(m, torch.nn.Conv2d):
+        torch.nn.init.normal_(m.weight, mean=0.0, std=0.02)
+        if m.bias is not None:
+            torch.nn.init.zeros_(m.bias)
+    elif isinstance(m, torch.nn.LayerNorm):
+        if m.weight is not None:
+            torch.nn.init.ones_(m.weight)
+        if m.bias is not None:
+            torch.nn.init.zeros_(m.bias)
+
+
+def test_swinv2(device, batch=2, image_size=64, window_size=8):
+    """SwinV2 backbone with batch > 1 exercises the SHIFTED-window attention (torch.roll
+    composed with window partition/reverse) -- the path that used to fail codegen with
+    "Unlinearized floor/mod in DMA index" (GitHub issue #251)."""
+    torch.manual_seed(0)
+    cfg = Swinv2Config(
+        image_size=image_size,
+        patch_size=4,
+        embed_dim=96,
+        depths=[2],            # 2 blocks -> block 1 is the shifted-window block
+        num_heads=[3],
+        window_size=window_size,
+    )
+    with torch.no_grad():
+        model = Swinv2Model(cfg).eval()
+        model.apply(_init_weights)
+
+        x = torch.randn(batch, 3, image_size, image_size)
+        x_device = x.to(device=device)
+        model.to(device)
+        opt_model = torch.compile(dynamic=False)(model)
+        out_device = opt_model(pixel_values=x_device).last_hidden_state
+
+        out_cpu = model.cpu()(pixel_values=x.cpu()).last_hidden_state
+
+    test_result(f"SwinV2 shifted-window (batch={batch})", out_device, out_cpu)
+    print("Max diff >", torch.max(torch.abs(out_device.cpu() - out_cpu)))
+    print("SwinV2 Simulation Done")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run SwinV2 shifted-window test")
+    parser.add_argument("--batch", type=int, default=2)
+    parser.add_argument("--image_size", type=int, default=64)
+    parser.add_argument("--window_size", type=int, default=8)
+    args = parser.parse_args()
+    test_swinv2(
+        torch.device("npu:0"),
+        batch=args.batch,
+        image_size=args.image_size,
+        window_size=args.window_size,
+    )

--- a/tests/ops/reduce/test_reduce.py
+++ b/tests/ops/reduce/test_reduce.py
@@ -25,6 +25,24 @@ def test_reduce_sum2(device, size, dim=-1, keepdim=False):
     out = reduce_sum(x.cpu(), dim, keepdim)
     test_result("ReduceMax", res, out)
 
+def test_reduce_gather_bias(device, NW=4, H=3, Q=32, K=32, T=64):
+    """A reduction fused with an INDIRECT gather bias, as in SwinV2 cosine-window
+    attention: score[w,h,q,k] + table[idx[q,k], h] -> amax over the key axis. The gather
+    blocks the head*query dim-merge, so the reduction tile stays 4-D. The reduction axis
+    must be hoisted to the outermost in-lane position; the 4-D reduction tile path used to
+    skip that reorder and reduce a batch axis (head) instead of the key axis, so head 0's
+    max picked up head 1's values (needs H>=2 and NW>=2 to expose the head bleed)."""
+    def fn(score, idx, table):
+        bias = table[idx.reshape(-1)].reshape(Q, K, H).permute(2, 0, 1).unsqueeze(0)
+        return (score + bias).amax(dim=-1)
+    torch.manual_seed(0)
+    score = torch.randn(NW, H, Q, K).to(device=device)
+    idx = torch.randint(0, T, (Q, K)).to(device=device)
+    table = torch.randn(T, H).to(device=device)
+    res = torch.compile(dynamic=False)(fn)(score, idx, table)
+    out = fn(score.cpu(), idx.cpu(), table.cpu())
+    test_result("ReduceGatherBias", res, out)
+
 if __name__ == "__main__":
     import argparse
 
@@ -39,3 +57,4 @@ if __name__ == "__main__":
     test_reduce_sum(device, (327, 447), 1, keepdim=True)
     test_reduce_sum(device, (327, 447), 0, keepdim=True)
     test_reduce_sum2(device, shape)
+    test_reduce_gather_bias(device)


### PR DESCRIPTION
Enables SwinV2 (shifted-window attention) with batch > 1, resolving #251. The backbone now compiles and matches CPU end to end (max diff ~5e-6 for image 64 / window 8 / batch 2). Adds `tests/models/test_swinv2.py` as a self-hosted CI job and lists SwinV2 in the README model coverage.

Getting there cleared several independent walls, one commit each:

- **Make int max/min reductions dtype-aware (identity + combine)** — the frontend `reduction_init` returned `+/-inf` for max/min regardless of dtype, overflowing the int64 masked-fill. It now uses the dtype's representable extreme (`iinfo.min/max`), and `reduction_combine_vec` picks `maxsi/minsi` vs `maximumf/minimumf` by element type.

- **Lower torch.roll to narrow+cat** — the shifted-window cyclic shift expands to a modular `index_select` that axis-split cannot linearize. Replace it with a slice+cat lowering and realize the input so each slice reads a materialized buffer instead of the producer's reshaped view.

- **axis-split: flatten nested single-variable floor/mod** — window partition/reverse composes into a doubly-nested `ModularIndexing` that axis-split could not collapse; add divisibility-guarded identities that flatten it to one level.

- **Define empty_strided_cpu in the generated wrapper header** — the FxGraphCache replay path reached a wrapper whose header was missing the `empty_strided_cpu` binding.

- **Place the reduction axis outermost in the per-lane tile layout** — the reduction codegen models the per-lane tile as 2-D `[reduction | batch]` and hardcodes the reduction axis as the outer block, but `get_dma_info` only reordered ranks 2-3. SwinV2's gathered relative-position bias (4-D tile) and post-attention `var_mean` (6-D tile) left the reduction axis innermost, so the reduce collapsed a batch axis (head / token) instead of the reduction axis. Generalize the reorder to any rank.

- **Enable SwinV2** — add the model test, the self-hosted CI job, and the README entry.
