### PR TITLE
[Frontend] Store the template buffer when it outlives the fused epilogue

### DIFF
--- a/PyTorchSimFrontend/mlir/mlir_template.py
+++ b/PyTorchSimFrontend/mlir/mlir_template.py
@@ -645,11 +645,24 @@ class MLIRTemplateKernel(MLIRKernel, BaseMLIRHardwareInfo):
             code = self.def_dma_op("MVOUT", dram_var, index_list, tile_desc, lazy_mode=False)
             self.cse.generate(self.dma_stores, code, assignment = False)
 
+        def template_buffer_live():
+            # Inductor's remove_kernel_local_buffers() drops the template buffer only when
+            # every one of its users lives inside this fused kernel
+            # (Scheduler.can_buffer_be_removed_through_fusion). If it survived, some user is
+            # outside the kernel, so we must store it to DRAM -- whether or not a fused
+            # epilogue also stores its own output.
+            name = getattr(self, "template_buffer_name", None)
+            assert name is not None, (
+                "store_output() used by a template that never declared its output buffer; "
+                "call def_kernel()/def_conv_kernel() with outputs=[...] first"
+            )
+            return name not in self.removed_buffers
+
         body = IndentedBuffer()
         with self.epilogue_buffer_group.as_local():
             # Do dma store first to overlap epilogue nodes
             if self.reduction_fusion:
-                if len(self.stores._lines) == 0:
+                if template_buffer_live():
                     template_store()
                     body.splice(self.dma_stores)
                     self.dma_stores.clear()
@@ -668,7 +681,7 @@ class MLIRTemplateKernel(MLIRKernel, BaseMLIRHardwareInfo):
                 else:
                     compute_body.splice(self.loads)
                     compute_body.splice(self.compute)
-                    if len(self.stores._lines) == 0:
+                    if template_buffer_live():
                         template_store()
                 compute_body.splice(self.stores)
             if (compute_body.getvalue()):
@@ -689,6 +702,12 @@ class MLIRTemplateKernel(MLIRKernel, BaseMLIRHardwareInfo):
             raise RuntimeError(
                 f"{len(inputs) + len(outputs)=} != {len(names)=}, {inputs=}, {outputs=}, {names=}"
             )
+
+        # The template's own output buffer. codegen_epilogue_body() stores it to DRAM iff
+        # it survived Inductor's kernel-local buffer removal -- i.e. it still has a user
+        # outside this fused kernel.
+        if outputs:
+            self.template_buffer_name = outputs[0].get_name()
 
         if input_reorder is not None:
             assert len(inputs) == len(input_reorder)
@@ -757,6 +776,12 @@ class MLIRTemplateKernel(MLIRKernel, BaseMLIRHardwareInfo):
             raise RuntimeError(
                 f"{len(inputs) + len(outputs)=} != {len(names)=}, {inputs=}, {outputs=}, {names=}"
             )
+
+        # The template's own output buffer. codegen_epilogue_body() stores it to DRAM iff
+        # it survived Inductor's kernel-local buffer removal -- i.e. it still has a user
+        # outside this fused kernel.
+        if outputs:
+            self.template_buffer_name = outputs[0].get_name()
 
         if input_reorder is not None:
             assert len(inputs) == len(input_reorder)


### PR DESCRIPTION
## Problem

`codegen_epilogue_body()` decided whether to emit the template buffer's `MVOUT` by asking *"did a fused epilogue already store something?"*:

```python
if len(self.stores._lines) == 0:
    template_store()
```

That is a **proxy** for the real question — *"does anything outside this kernel still read the template buffer?"* — and it is wrong in two of four cases:

| epilogue fused | template buffer | correct | proxy |
|---|---|---|---|
| no | live | store | store ✅ |
| no | **dead** | skip | **store** ❌ (emits MVOUT for a pruned DRAM arg) |
| **yes** | **live** | store | **skip** ❌ (buffer never written) |
| yes | dead | skip | skip ✅ |

## Impact: DeepSeek-V3 MoE gate silently corrupted

The gate is `sigmoid(mm(hidden, gate_w) + bias)`, so `add`+`sigmoid` fuse onto the GEMM template. But the raw `mm` result is **also** read by a later gather kernel:

```
mlir_kernel_21(arg0_1, arg1_1, arg2_1, buf0, buf1)   # buf0 declared as output, never stored
extension_kernel_50(buf14, buf0, buf15)              # buf0 read (arg mode 1 = input)
```

`buf0` stayed at its `empty_strided` value (all zeros), scrambling expert routing.

**Every config was affected.** At the `mm` site both 8x8 and 32x32 show the identical `max abs diff 1.77072`. Only 8x8 crossed the test's very loose tolerance (`rtol=3e-1, atol=2e-1`), giving final `Max abs diff 0.2546`; 32x32 landed just under and passed. This is not an 8x8-specific bug.

Not fp16 (all buffers are `float32`) and not error accumulation (npu is exactly `0`, and 768/768 elements are wrong on the *first* kernel).

## Fix

Ask the real question. Inductor already answers it: `Kernel.remove_kernel_local_buffers()` drops a buffer only when `Scheduler.can_buffer_be_removed_through_fusion()` finds every user inside this fused kernel:

```python
all(user.is_weak or user.get_name() in fused_node_names for user in users)
```

A buffer that **survived** removal therefore has an outside user and must be stored. So rather than re-deriving users, read the scheduler's verdict:

```python
# def_kernel() and def_conv_kernel()  (conv has its own implementation)
if outputs:
    self.template_buffer_name = outputs[0].get_name()

# codegen_epilogue_body()
def template_buffer_live():
    name = getattr(self, "template_buffer_name", None)
    assert name is not None, "store_output() without def_kernel(outputs=[...])"
    return name not in self.removed_buffers

if template_buffer_live():
    template_store()
```

The proxy is removed from **both** the main and the `reduction_fusion` branches.

Two details worth calling out:

- Use the **kernel-local** `self.removed_buffers`, not `V.graph.removed_buffers`. `remove_buffer()` populates the former; the latter is still empty when the store hook runs (instrumented: dead case shows `kernel.removed=['buf0']`, `graph.removed=[]`).
- `def_conv_kernel()` does not call `def_kernel()`, so both need the recording or conv templates would lose their store.

This is the same bug class as the existing `YV_LIVE` gate in `mlir_sort_template.py` — sort had the guard, the shared template path did not.

## Side effect (please note)

A previously **missing** `MVOUT` now issues, so DRAM traffic and cycle counts **rise** for any model with a live template buffer under a fused epilogue. That is the correct cost rather than a regression, but reported cycles / speedup artifacts will shift.

## Verification (8x8 config)

- `test_deepseek_v3_base`: `Max abs diff 0.2546` FAIL → **Pass**
- dead template buffer (`relu(mm)`): `%Y` arg still pruned, still a single `MVOUT` — unchanged, no undeclared-SSA
- live template buffer (`logits, scores = mm(x,w), sigmoid(mm+b)` returning both): logits all-zero (diff 80.06) → diff 6.5e-05
- trace `.so` + TOGSim timing path runs and produces a cycle log with the extra store
- regressions pass: `test_bmm_reduction` (covers the `reduction_fusion` branch), `test_matmul`, `test_bmm`, `test_conv2d` (13 cases), `test_cnn`, `test_group_conv`, `test_pool`, `test_reduce`, `test_softmax`, `test_layernorm`, `test_mlp`

## Not addressed

The `test_fusion` failure in the same CI run is unrelated: `Max abs diff 0.000198` on values of magnitude ~100 is fp32 noise against the default `atol=1e-4`. Likewise the `test_conv2d` wrapper3 failure is a Simulator `SIGKILL` (OOM), not a numeric issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQyMKNaTWHRT5sBNifJJ9Z