### PR TITLE
[Model] Enable CLIP vision backbone (issue #252)

### DIFF
--- a/.github/workflows/pytorchsim_test.yml
+++ b/.github/workflows/pytorchsim_test.yml
@@ -19,8 +19,8 @@ on:
 # Runner policy: the CPU-only CI image is small enough to pull on GitHub-hosted
 # runners, so op and model tests run on ubuntu-latest. The memory/time-intensive
 # jobs stay on self-hosted: test_deepseek (largest model), test_swinv2 (SwinV2
-# shifted-window backbone), test_diffusion (UNet2D simulation OOMs the hosted
-# runner), and test_accuracy (accuracy + speedup).
+# shifted-window backbone), test_clip (CLIP vision backbone), test_diffusion
+# (UNet2D simulation OOMs the hosted runner), and test_accuracy (accuracy + speedup).
 jobs:
   test_add:
     name: Run test_add.py
@@ -763,6 +763,26 @@ jobs:
           docker run --rm \
             -e TOGSIM_CONFIG="${{ inputs.togsim_config }}" \
             ${{ inputs.image_name }} python3 PyTorchSim/tests/models/test_swinv2.py
+
+  test_clip:
+    name: Run test_clip.py
+    # CLIP vision backbone; keep it on a self-hosted runner like the other
+    # model tests (the 32x32 patch conv expands to many tiles at small arrays).
+    runs-on: self-hosted
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run test_clip.py
+        run: |
+          echo "Running test_clip.py"
+          docker run --rm \
+            -e TOGSIM_CONFIG="${{ inputs.togsim_config }}" \
+            ${{ inputs.image_name }} python3 PyTorchSim/tests/models/test_clip.py
 
   test_eager:
     name: Run test_eager.py

--- a/PyTorchSimFrontend/mlir/mlir_template.py
+++ b/PyTorchSimFrontend/mlir/mlir_template.py
@@ -347,7 +347,13 @@ class MLIRTemplateKernel(MLIRKernel, BaseMLIRHardwareInfo):
                             max_used_spad_size = used_spad_size
                             max_k_h_w = k_h
                             mapping = (k_h, K_W, o_h, o_w, M, N, K)
-        if max_used_spad_size == 0:
+        # Raise only when NO tile fits SPAD. The max_used_spad_size / max_k_h_w
+        # tracking above only records the largest-k_h tile (max_k_h_w starts at
+        # K_W, so it never fires unless the full-kernel tile fits) and is not
+        # returned -- the sorted tile_candidates is. Guarding on it wrongly
+        # rejected convs whose full-kernel tile overflows SPAD (e.g. a batched
+        # CLIP patch conv) even though smaller-k_h tiles fit. See issue #252.
+        if not tile_candidates:
             raise RuntimeError("Cannot find a valid mapping")
         tile_candidates = sorted(tile_candidates, key=lambda x: x[0], reverse=True)
         tile_candidates = [v for _, v in tile_candidates]
@@ -383,7 +389,7 @@ class MLIRTemplateKernel(MLIRKernel, BaseMLIRHardwareInfo):
                             max_used_spad_size = used_spad_size
                             max_k_h_w = k_h * k_w
                             mapping = (k_h, k_w, o_h, M, M, N, K)
-        if max_used_spad_size == 0:
+        if not tile_candidates:
             raise RuntimeError("Cannot find a valid mapping")
         tile_candidates = sorted(tile_candidates, key=lambda x: x[0], reverse=True)
         tile_candidates = [v for _, v in tile_candidates]

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ PyTorchSim **supports**:
 | Llama 2/3 | 🤗 | ✅ | `tests/models/Llama/` (blocks & decode-style paths) |
 | DeepSeek-V3 (base) | 🤗 | ✅ | `tests/models/DeepSeek/` — several ops(e.g., gate ops) are not cycle-modeled |
 | SwinV2 | 🤗 | ✅ | `tests/models/test_swinv2.py` (shifted-window attention) |
+| CLIP (vision) | 🤗 | ✅ | `tests/models/test_clip.py` |
 | Llama-4 | 🤗 | ⏳ | In development |
 | Broader model support | — | ⏳ | In development |
 <!-- ## Requirements

--- a/tests/models/test_clip.py
+++ b/tests/models/test_clip.py
@@ -1,0 +1,71 @@
+import argparse
+import os
+import sys
+
+import torch
+from transformers import CLIPVisionConfig, CLIPVisionModel
+
+sys.path.insert(0, os.path.join(os.environ.get("TORCHSIM_DIR", default="/workspace/PyTorchSim"), "tests"))
+from _pytorchsim_utils import test_result
+
+
+def _init_weights(m):
+    if isinstance(m, torch.nn.Linear):
+        torch.nn.init.normal_(m.weight, mean=0.0, std=0.02)
+        if m.bias is not None:
+            torch.nn.init.zeros_(m.bias)
+    elif isinstance(m, torch.nn.Conv2d):
+        torch.nn.init.normal_(m.weight, mean=0.0, std=0.02)
+        if m.bias is not None:
+            torch.nn.init.zeros_(m.bias)
+    elif isinstance(m, torch.nn.LayerNorm):
+        if m.weight is not None:
+            torch.nn.init.ones_(m.weight)
+        if m.bias is not None:
+            torch.nn.init.zeros_(m.bias)
+
+
+def test_clip(device, batch=2, image_size=224, patch_size=32, num_layers=2):
+    """CLIP vision backbone with batch > 1. The patch-embedding conv (kernel = stride =
+    patch_size) routes to the multi-tile conv mapping, whose full-kernel tile overflows
+    SPAD at batch > 1 -- that used to raise "Cannot find a valid mapping" (GitHub issue
+    #252)."""
+    torch.manual_seed(0)
+    cfg = CLIPVisionConfig(
+        hidden_size=768,
+        intermediate_size=3072,
+        num_hidden_layers=num_layers,
+        num_attention_heads=12,
+        image_size=image_size,
+        patch_size=patch_size,
+    )
+    with torch.no_grad():
+        model = CLIPVisionModel(cfg).eval()
+        model.apply(_init_weights)
+
+        x = torch.randn(batch, 3, image_size, image_size)
+        out_cpu = model(pixel_values=x.cpu()).last_hidden_state
+
+        model.to(device)
+        opt_model = torch.compile(dynamic=False)(model)
+        out_device = opt_model(pixel_values=x.to(device)).last_hidden_state
+
+    test_result(f"CLIP vision (batch={batch})", out_device, out_cpu)
+    print("Max diff >", torch.max(torch.abs(out_device.cpu() - out_cpu)))
+    print("CLIP Simulation Done")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run CLIP vision test")
+    parser.add_argument("--batch", type=int, default=2)
+    parser.add_argument("--image_size", type=int, default=224)
+    parser.add_argument("--patch_size", type=int, default=32)
+    parser.add_argument("--num_layers", type=int, default=2)
+    args = parser.parse_args()
+    test_clip(
+        torch.device("npu:0"),
+        batch=args.batch,
+        image_size=args.image_size,
+        patch_size=args.patch_size,
+        num_layers=args.num_layers,
+    )

--- a/tests/ops/conv/test_conv2d.py
+++ b/tests/ops/conv/test_conv2d.py
@@ -39,4 +39,7 @@ if __name__ == "__main__":
         test_conv2d(device, batch_size=1, in_channels=128, out_channels=256, input_size=2, kernel_size=1, stride=1, padding=0)
         test_conv2d(device, batch_size=1, in_channels=128, out_channels=256, input_size=14, kernel_size=1, stride=2, padding=0)
         test_conv2d(device, batch_size=1, in_channels=3, out_channels=768, input_size=224, kernel_size=16,stride=16, padding=0)
+        # batch>1 patch conv (large kernel/out-channels): the multi-tile mapping's
+        # full-kernel tile overflows SPAD while smaller-k_h tiles still fit (issue #252)
+        test_conv2d(device, batch_size=2, in_channels=3, out_channels=768, input_size=64, kernel_size=32, stride=32, padding=0)
         test_conv2d(device, batch_size=1, in_channels=8, out_channels=16, input_size=1, kernel_size=1,stride=1, padding=0)


### PR DESCRIPTION
Enables the CLIP vision backbone with `batch > 1`, resolving #252. The vision transformer now compiles and matches CPU end to end (max diff ~1e-5). Adds `tests/models/test_clip.py` as a self-hosted CI job and lists CLIP in the README model coverage.

**Root cause.** A CLIP ViT-B/32 patch embedding is a `Conv2d(3, 768, kernel_size=32, stride=32)`. At `batch > 1` this routes to `conv_multi_tile_mapping`, which collects every tile that fits SPAD into `tile_candidates` (returned sorted) but guarded the "Cannot find a valid mapping" error on `max_used_spad_size` instead of on `tile_candidates`. `max_used_spad_size` is only bumped when a candidate also satisfies `max_k_h_w <= k_h`, and `max_k_h_w` is initialized to `K_W`, so it only ever fires for the full-kernel (`k_h == K_H`) tile. That full-kernel tile overflows SPAD at `batch > 1` (its per-lane footprint exceeds the budget), so the guard raised even though smaller-`k_h` tiles fit and were already in `tile_candidates`. The `mapping` variable it tracks is never returned.

**Fix.** Guard on `not tile_candidates` instead, so a conv is rejected only when no tile fits at all. The returned candidate list is unchanged, so convs that already compiled are unaffected; only the wrongly-rejected batched convs now proceed.

**Verification.**
- CLIP vision (`CLIPVisionModel`, patch 32, batch 2) matches CPU end to end (max diff ~1e-5).
- Added `test_conv2d.py` batched patch-conv case: fails with "Cannot find a valid mapping" before the fix, passes after.
- `test_cnn` and the existing `test_conv2d` cases are unchanged.
