### PR TITLE
[Frontend] Fix conv wrapper crash when the input is a view of a lower-rank buffer

### DIFF
--- a/.github/workflows/pytorchsim_test.yml
+++ b/.github/workflows/pytorchsim_test.yml
@@ -166,6 +166,24 @@ jobs:
             -e TOGSIM_CONFIG="${{ inputs.togsim_config }}" \
             ${{ inputs.image_name }} python3 PyTorchSim/tests/ops/conv/test_conv2d.py
 
+  test_conv_view_input:
+    name: Run test_conv_view_input.py
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run test_conv_view_input.py
+        run: |
+          echo "Running test_conv_view_input.py"
+          docker run --rm \
+            -e TOGSIM_CONFIG="${{ inputs.togsim_config }}" \
+            ${{ inputs.image_name }} python3 PyTorchSim/tests/ops/conv/test_conv_view_input.py
+
   test_cat:
     name: Run test_cat.py
     runs-on: ubuntu-latest

--- a/PyTorchSimFrontend/mlir/mlir_conv_common.py
+++ b/PyTorchSimFrontend/mlir/mlir_conv_common.py
@@ -92,6 +92,19 @@ class MLIRConvCommonTemplate(MLIRTemplate):
         Y = self.output_node
         Bias = None if len(self.input_nodes) == 2 else self.input_nodes[2]
 
+        # The wrapper must not infer geometry from the runtime tensor: an input node can be
+        # a ReinterpretView, in which case call_kernel hands the wrapper the *base buffer*
+        # (possibly a different rank).  Bake the layout codegen assumed into the wrapper and
+        # rebuild the logical view from it, so the wrapper is correct for either argument.
+        def _layout(node):
+            return (tuple(int(s) for s in node.get_size()),
+                    tuple(int(s) for s in node.get_stride()),
+                    int(node.layout.offset))
+
+        X_size, X_stride, X_offset = _layout(X)
+        W_size, W_stride, W_offset = _layout(W)
+        _, _, I_H, I_W = X_size
+
         options = dict(
             kernel=self.kernel,
             KERNEL_NAME=kernel_name,
@@ -102,6 +115,16 @@ class MLIRConvCommonTemplate(MLIRTemplate):
             OUTPUT=Y,
             PADDING_H=self.padding[0],
             PADDING_W=self.padding[1],
+            X_SIZE=X_size,
+            X_STRIDE=X_stride,
+            X_OFFSET=X_offset,
+            W_SIZE=W_size,
+            W_STRIDE=W_stride,
+            W_OFFSET=W_offset,
+            I_H=I_H,
+            I_W=I_W,
+            X_PADDED_SIZE=(X_size[0], X_size[1],
+                           I_H + 2 * self.padding[0], I_W + 2 * self.padding[1]),
             VALIDATION_MODE=extension_config.pytorchsim_functional_mode,
             input_reorder=self.input_reorder
         )

--- a/PyTorchSimFrontend/mlir/mlir_conv_mt_template.py
+++ b/PyTorchSimFrontend/mlir/mlir_conv_mt_template.py
@@ -100,12 +100,15 @@ func.func @{{ KERNEL_NAME }}{{kernel.def_conv_kernel(inputs=[X, W, BIAS], output
 class MLIRConvMultiTileTemplate(MLIRConvCommonTemplate):
     WRAPPER_TEMPLATE = r"""
 def {{ FUNC_NAME }}{{kernel.def_wrapper()}}:
+    # Rebuild the logical NCHW inputs from the layout codegen assumed. The runtime argument
+    # may be the base buffer of a ReinterpretView (different rank/shape), so geometry is
+    # never inferred from X.shape.
+    X = reinterpret_tensor(X, {{ X_SIZE }}, {{ X_STRIDE }}, {{ X_OFFSET }})
+    W = reinterpret_tensor(W, {{ W_SIZE }}, {{ W_STRIDE }}, {{ W_OFFSET }})
+
     # Padding input
-    padded_shape = list(X.shape)
-    padded_shape[2] += 2 * {{ PADDING_H }}
-    padded_shape[3] += 2 * {{ PADDING_W }}
-    X_padding = torch.zeros(padded_shape).to(device=X.device)
-    X_padding[:, :, {{ PADDING_H }}:X.shape[2] + {{ PADDING_H }}, {{ PADDING_W }}:X.shape[3] + {{ PADDING_W }}] = X
+    X_padding = torch.zeros({{ X_PADDED_SIZE }}, device=X.device, dtype=X.dtype)
+    X_padding[:, :, {{ PADDING_H }}:{{ PADDING_H + I_H }}, {{ PADDING_W }}:{{ PADDING_W + I_W }}] = X
 
     # Tanspose inputs
     {%- for buf, name in kernel.get_conv_inputs().items() %}

--- a/PyTorchSimFrontend/mlir/mlir_conv_sb_template.py
+++ b/PyTorchSimFrontend/mlir/mlir_conv_sb_template.py
@@ -101,12 +101,15 @@ func.func @{{ KERNEL_NAME }}{{kernel.def_conv_kernel(inputs=[X, W, BIAS], output
 class MLIRConvSingleBatchTemplate(MLIRConvCommonTemplate):
     WRAPPER_TEMPLATE = r"""
 def {{ FUNC_NAME }}{{kernel.def_wrapper()}}:
+    # Rebuild the logical NCHW inputs from the layout codegen assumed. The runtime argument
+    # may be the base buffer of a ReinterpretView (different rank/shape), so geometry is
+    # never inferred from X.shape.
+    X = reinterpret_tensor(X, {{ X_SIZE }}, {{ X_STRIDE }}, {{ X_OFFSET }})
+    W = reinterpret_tensor(W, {{ W_SIZE }}, {{ W_STRIDE }}, {{ W_OFFSET }})
+
     # Padding input
-    padded_shape = list(X.shape)
-    padded_shape[2] += 2 * {{ PADDING_H }}
-    padded_shape[3] += 2 * {{ PADDING_W }}
-    X_padding = torch.zeros(padded_shape).to(device=X.device)
-    X_padding[:, :, {{ PADDING_H }}:X.shape[2] + {{ PADDING_H }}, {{ PADDING_W }}:X.shape[3] + {{ PADDING_W }}] = X
+    X_padding = torch.zeros({{ X_PADDED_SIZE }}, device=X.device, dtype=X.dtype)
+    X_padding[:, :, {{ PADDING_H }}:{{ PADDING_H + I_H }}, {{ PADDING_W }}:{{ PADDING_W + I_W }}] = X
 
     # Tanspose inputs
     {%- for buf, name in kernel.get_conv_inputs().items() %}

--- a/PyTorchSimFrontend/mlir/mlir_conv_sbs_template.py
+++ b/PyTorchSimFrontend/mlir/mlir_conv_sbs_template.py
@@ -101,12 +101,15 @@ func.func @{{ KERNEL_NAME }}{{kernel.def_conv_kernel(inputs=[X, W, BIAS], output
 class MLIRConvSingleBatchStridedTemplate(MLIRConvCommonTemplate):
     WRAPPER_TEMPLATE = r"""
 def {{ FUNC_NAME }}{{kernel.def_wrapper()}}:
+    # Rebuild the logical NCHW inputs from the layout codegen assumed. The runtime argument
+    # may be the base buffer of a ReinterpretView (different rank/shape), so geometry is
+    # never inferred from X.shape.
+    X = reinterpret_tensor(X, {{ X_SIZE }}, {{ X_STRIDE }}, {{ X_OFFSET }})
+    W = reinterpret_tensor(W, {{ W_SIZE }}, {{ W_STRIDE }}, {{ W_OFFSET }})
+
     # Padding input
-    padded_shape = list(X.shape)
-    padded_shape[2] += 2 * {{ PADDING_H }}
-    padded_shape[3] += 2 * {{ PADDING_W }}
-    X_padding = torch.zeros(padded_shape).to(device=X.device)
-    X_padding[:, :, {{ PADDING_H }}:X.shape[2] + {{ PADDING_H }}, {{ PADDING_W }}:X.shape[3] + {{ PADDING_W }}] = X
+    X_padding = torch.zeros({{ X_PADDED_SIZE }}, device=X.device, dtype=X.dtype)
+    X_padding[:, :, {{ PADDING_H }}:{{ PADDING_H + I_H }}, {{ PADDING_W }}:{{ PADDING_W + I_W }}] = X
 
     # Tanspose inputs
     {%- for buf, name in kernel.get_conv_inputs().items() %}

--- a/PyTorchSimFrontend/mlir/mlir_conv_template.py
+++ b/PyTorchSimFrontend/mlir/mlir_conv_template.py
@@ -105,12 +105,15 @@ func.func @{{ KERNEL_NAME }}{{kernel.def_conv_kernel(inputs=[X, W, BIAS], output
 class MLIRConvTemplate(MLIRConvCommonTemplate):
     WRAPPER_TEMPLATE = r"""
 def {{ FUNC_NAME }}{{kernel.def_wrapper()}}:
+    # Rebuild the logical NCHW inputs from the layout codegen assumed. The runtime argument
+    # may be the base buffer of a ReinterpretView (different rank/shape), so geometry is
+    # never inferred from X.shape.
+    X = reinterpret_tensor(X, {{ X_SIZE }}, {{ X_STRIDE }}, {{ X_OFFSET }})
+    W = reinterpret_tensor(W, {{ W_SIZE }}, {{ W_STRIDE }}, {{ W_OFFSET }})
+
     # Padding input
-    padded_shape = list(X.shape)
-    padded_shape[2] += 2 * {{ PADDING_H }}
-    padded_shape[3] += 2 * {{ PADDING_W }}
-    X_padding = torch.zeros(padded_shape).to(device=X.device)
-    X_padding[:, :, {{ PADDING_H }}:X.shape[2] + {{ PADDING_H }}, {{ PADDING_W }}:X.shape[3] + {{ PADDING_W }}] = X
+    X_padding = torch.zeros({{ X_PADDED_SIZE }}, device=X.device, dtype=X.dtype)
+    X_padding[:, :, {{ PADDING_H }}:{{ PADDING_H + I_H }}, {{ PADDING_W }}:{{ PADDING_W + I_W }}] = X
 
     # Tanspose inputs
     {%- for buf, name in kernel.get_conv_inputs().items() %}

--- a/tests/ops/conv/test_conv_view_input.py
+++ b/tests/ops/conv/test_conv_view_input.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import torch
+import torch._dynamo
+sys.path.insert(0, os.path.join(os.environ.get("TORCHSIM_DIR", default="/workspace/PyTorchSim"), "tests"))
+from _pytorchsim_utils import test_result
+
+def test_conv_view_input(device, batch_size=1, channels=32, height=8, width=8, out_channels=16, kernel_size=2):
+    """Conv whose input is a free view (ReinterpretView) over a lower-rank buffer.
+
+    A contiguous (B, H*W, C) buffer already is the channels_last layout of (B, C, H, W),
+    so permute+reshape is a pure view: inductor inserts no materializing copy and the conv
+    wrapper is handed the raw 3D base buffer. The wrapper must rebuild the 4D logical input
+    from the layout codegen assumed instead of reading X.shape. This is SegFormer's
+    efficient-attention spatial-reduction conv.
+    """
+    def conv_on_view(a, b, bias):
+        x = a * 2.0
+        h = x.permute(0, 2, 1).reshape(batch_size, channels, height, width)
+        return torch.nn.functional.conv2d(h, b, bias, stride=kernel_size, padding=0)
+    torch.manual_seed(0)
+    conv_input = torch.randn(batch_size, height * width, channels)
+    conv_kernel = torch.randn(out_channels, channels, kernel_size, kernel_size)
+    conv_bias = torch.randn(out_channels)
+    out = conv_on_view(conv_input, conv_kernel, conv_bias)
+    opt_fn = torch.compile(dynamic=False)(conv_on_view)
+    res = opt_fn(conv_input.to(device=device), conv_kernel.to(device=device), conv_bias.to(device=device))
+    test_result("Conv2d view input", res, out, rtol=1e-3, atol=1e-3)
+    print("Max diff > ", torch.max(torch.abs(res.cpu() - out)))
+
+if __name__ == "__main__":
+    device = torch.device("npu:0")
+    torch._dynamo.config.cache_size_limit = 64
+    with torch.no_grad():
+        test_conv_view_input(device)
+        test_conv_view_input(device, batch_size=1, channels=64, height=16, width=16, out_channels=32, kernel_size=4)


### PR DESCRIPTION
Fixes a conv codegen bug where the generated wrapper crashes with

```
padded_shape[3] += 2 * 0
IndexError: list index out of range
```

## Root cause

A conv input node can be a `ReinterpretView`. `call_kernel` passes template args by
buffer **name**, so the wrapper is handed the *base buffer*, whose rank/shape may differ
from the view codegen assumed:

| | X |
|---|---|
| codegen (`extract_info`) | `X.layout.size = [1, 32, 8, 8]` (the 4D view) |
| runtime (wrapper) | `X.shape = (1, 64, 32)` (the base buffer) |

The wrapper then inferred geometry from the runtime tensor (`list(X.shape)`, `X.shape[2]`,
`X.shape[3]`) and blew up.

It only fires when the view is **free**: a contiguous `(B, N, C)` buffer already *is* the
channels_last layout of `(B, C, H, W)`, so inductor inserts no materializing copy. That is
exactly the transformer `(B, N, C) -> (B, C, H, W)` pattern — e.g. SegFormer's
efficient-attention spatial-reduction conv (`Conv2d(C, C, k=sr, stride=sr)`, padding 0).
When the layout does *not* match, inductor inserts a copy kernel, a real 4D buffer arrives,
and the bug is invisible. That is why it went unnoticed.

## Fix

Stop inferring geometry from the runtime tensor. Bake the size/stride/offset the codegen
used into the wrapper and rebuild the logical NCHW inputs from it:

```python
X = reinterpret_tensor(X, (1, 32, 8, 8), (0, 1, 256, 32), 0)
W = reinterpret_tensor(W, (16, 32, 2, 2), (128, 1, 64, 32), 0)
X_padding = torch.zeros((1, 32, 8, 8), device=X.device, dtype=X.dtype)
X_padding[:, :, 0:8, 0:8] = X
```

`X.layout` describes the data within the storage of the tensor that arrives (both come from
the same node), so the reinterpret is correct — and idempotent — whether the wrapper is
handed the base buffer, an already reinterpreted view, or a materialized copy.

The conv templates were the only place reading `.shape` at runtime; everything else already
derives geometry from the node layout at codegen time. **No change to `call_kernel`,
`mlir_argdefs`, the MLIR signature, or `arg_attributes`** — the call site still passes the
raw base buffer and it now works.

Also fixed for free: the padding buffer was allocated via `torch.zeros(shape)` (always f32)
then `.to(device=...)` (CPU round-trip). It now allocates directly on device with `X.dtype`.

## Verification

- New regression test `tests/ops/conv/test_conv_view_input.py`: fails with the above
  `IndexError` on the pre-fix wrapper, passes after (max diff 2.3e-05 / 2e-04 vs CPU).
- Normal conv path (real 4D buffer, `padding=1`) unchanged and numerically correct
  (max diff 3.8e-05 vs CPU); `reinterpret_tensor` is an identity there.

## Follow-ups (not in this PR)

- `padding == 0` fast path: shapes are literals now, so the `zeros` alloc + full copy can be
  skipped for 1x1 / strided convs.
- `mlir_argdefs` derives `buffer_types` numel from the *base* buffer, so a slicing view
  feeding e.g. gemm can still get a wrong MLIR arg size. Same class of bug, separate fix.
- `def_conv_kernel` patches the signature with `re.sub(r'(\d+)(?=xf32)', ...)`, hardcoding
  `xf32`; an f16 conv would not get its padded input size applied.

Found while checking #254 on this branch: SegFormer no longer hits the originally reported
`Not supporting format` error, but was blocked here instead.
