### PR TITLE
[Model] Enable ConvNeXt V2 with batch > 1 (issue #255)

### DIFF
--- a/.github/workflows/pytorchsim_test.yml
+++ b/.github/workflows/pytorchsim_test.yml
@@ -19,8 +19,9 @@ on:
 # Runner policy: the CPU-only CI image is small enough to pull on GitHub-hosted
 # runners, so op and model tests run on ubuntu-latest. The memory/time-intensive
 # jobs stay on self-hosted: test_deepseek (largest model), test_swinv2 (SwinV2
-# shifted-window backbone), test_clip (CLIP vision backbone), test_diffusion
-# (UNet2D simulation OOMs the hosted runner), and test_accuracy (accuracy + speedup).
+# shifted-window backbone), test_clip (CLIP vision backbone), test_convnextv2
+# (ConvNeXt V2 backbone), test_diffusion (UNet2D simulation OOMs the hosted
+# runner), and test_accuracy (accuracy + speedup).
 jobs:
   test_add:
     name: Run test_add.py
@@ -802,6 +803,26 @@ jobs:
           docker run --rm \
             -e TOGSIM_CONFIG="${{ inputs.togsim_config }}" \
             ${{ inputs.image_name }} python3 PyTorchSim/tests/models/test_clip.py
+
+  test_convnextv2:
+    name: Run test_convnextv2.py
+    # ConvNeXt V2 backbone; keep it on a self-hosted runner like the other model
+    # tests (the depthwise 7x7 conv lowers to one gather kernel per tap).
+    runs-on: self-hosted
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run test_convnextv2.py
+        run: |
+          echo "Running test_convnextv2.py"
+          docker run --rm \
+            -e TOGSIM_CONFIG="${{ inputs.togsim_config }}" \
+            ${{ inputs.image_name }} python3 PyTorchSim/tests/models/test_convnextv2.py
 
   test_eager:
     name: Run test_eager.py

--- a/PyTorchSimFrontend/extension_codecache.py
+++ b/PyTorchSimFrontend/extension_codecache.py
@@ -208,11 +208,11 @@ class MLIRCodeCache:
             # the shared spad. Matches the GEMM tiling gate (max_spad_size = spad/2).
             spad_budget = extension_config.CONFIG_SPAD_INFO["spad_size"] // 2
             if spad_budget < spad_usage:
-                logger.debug(
-                    f"Scratchpad size exceeded: required {spad_usage} bytes, but only "
-                    f"{spad_budget} bytes (spad/2, double-buffer budget) available."
+                raise SpadOverflowError(
+                    f"Scratchpad size exceeded: kernel needs {spad_usage} bytes/lane, but only "
+                    f"{spad_budget} bytes/lane (spad/2, double-buffer budget) are available. "
+                    f"tile_size={kwargs.get('tile_size')}, origins={origins}, path={write_path}"
                 )
-                raise SpadOverflowError()
 
             # Launch tile graph generator
             gem5_pad_cmd = shlex.split(gem5_cmds[0])

--- a/PyTorchSimFrontend/mlir/mlir_bmm_template.py
+++ b/PyTorchSimFrontend/mlir/mlir_bmm_template.py
@@ -152,11 +152,13 @@ func.func @{{ KERNEL_NAME }}{{kernel.def_kernel(inputs=[X, W, Bias], outputs=[Y]
 """
 
 class MLIRBMMTemplate(MLIRTemplate):
+    # 3-D frame (batch x M x N): batch + M row indices + the reduced N index.
+    REDUCTION_EPILOGUE_ALIASING = {"index0": "index0", "index1": "index2", "index2": "index1"}
+
     def __init__(self, input_nodes, layout, input_reorder=None):
         super().__init__("kernel", input_nodes, layout, input_reorder)
         self.support_epilogue_fusion = True
         self.support_prologue_fusion = True
-        self.support_reduction_fusion = True
 
     def render(self,
                kernel: MLIRTemplateKernel,
@@ -179,7 +181,7 @@ class MLIRBMMTemplate(MLIRTemplate):
         nr_reduction_nodes = [node for node in epilogue_nodes if node.is_reduction()] if epilogue_nodes is not None else []
         if nr_reduction_nodes:
             template = BMM_REDUCTION_TEMPLATE
-            epilogue_dim_aliasing = {"index0":"index0", "index1":"index2", "index2": "index1"}
+            epilogue_dim_aliasing = self.REDUCTION_EPILOGUE_ALIASING
             nr_rdim = 1
         elif prologue_nodes:
             template = BMM_PROLOGUE_TEMPLATE

--- a/PyTorchSimFrontend/mlir/mlir_codegen_backend.py
+++ b/PyTorchSimFrontend/mlir/mlir_codegen_backend.py
@@ -932,8 +932,11 @@ class MLIRKernel(mlir_common.BaseMLIRKernel):
         c_type = "uint64_t"
         new_name = f"index_expr_{compute_vec_size}"
         if new_name not in self.global_vars_dict:
-            self.header.writeline(f"{c_type} {new_name}_spad[{compute_vec_size*self.vector_lane}] __attribute__ ((section(\".spad\")));")
-            self.gem5_header.writeline(f"{c_type} {new_name}_spad[{compute_vec_size}] __attribute__((aligned(64)));")
+            # The initializer below stores two elements per iteration, so its last
+            # iteration writes one slot past compute_vec_size.
+            numel_per_lane = compute_vec_size + 1
+            self.header.writeline(f"{c_type} {new_name}_spad[{numel_per_lane}] __attribute__ ((section(\".spad\")));")
+            self.gem5_header.writeline(f"{c_type} {new_name}_spad[{numel_per_lane*self.vector_lane}] __attribute__((aligned(64)));")
             self.global_vars.writeline(f"memref.global @{new_name}_spad : {tile_shape}")
             self.global_vars_dict[new_name] = dict()
         sram_var = self.spad_cse.generate(self.spad_buffer, f"memref.get_global @{new_name}_spad : {tile_shape}")

--- a/PyTorchSimFrontend/mlir/mlir_conv_common.py
+++ b/PyTorchSimFrontend/mlir/mlir_conv_common.py
@@ -14,7 +14,6 @@ class MLIRConvCommonTemplate(MLIRTemplate):
         super().__init__("kernel", input_nodes, layout, input_reorder)
         self.support_epilogue_fusion = True
         self.support_prologue_fusion = False
-        self.support_reduction_fusion = False
         self.stride = kwargs["stride"]
         self.padding = kwargs["padding"]
         self.dilation = kwargs["dilation"]

--- a/PyTorchSimFrontend/mlir/mlir_gemm_template.py
+++ b/PyTorchSimFrontend/mlir/mlir_gemm_template.py
@@ -103,11 +103,13 @@ func.func @{{ KERNEL_NAME }}{{kernel.def_kernel(inputs=[X, W, Bias], outputs=[Y]
 """
 
 class MLIRGemmTemplate(MLIRTemplate):
+    # 2-D frame (M rows x N cols): one row index + the reduced N index.
+    REDUCTION_EPILOGUE_ALIASING = {"index0": "index1", "index1": "index0"}
+
     def __init__(self, input_nodes, layout, input_reorder=None):
         super().__init__("kernel", input_nodes, layout, input_reorder)
         self.support_epilogue_fusion = True
         self.support_prologue_fusion = True
-        self.support_reduction_fusion = True
 
     def render(self,
                kernel: MLIRTemplateKernel,
@@ -130,7 +132,7 @@ class MLIRGemmTemplate(MLIRTemplate):
             epilogue_dim_aliasing = {}
         elif n_epilogue_node>=1 and epilogue_nodes[0].is_reduction():
             template = GEMM_REDUCTION_TEMPLATE
-            epilogue_dim_aliasing = {"index0":"index1", "index1":"index0"}
+            epilogue_dim_aliasing = self.REDUCTION_EPILOGUE_ALIASING
             nr_rdim = 1
         else:
             template = GEMM_TEMPLATE

--- a/PyTorchSimFrontend/mlir/mlir_scheduling.py
+++ b/PyTorchSimFrontend/mlir/mlir_scheduling.py
@@ -1,9 +1,5 @@
 import os
-import math
 import sympy
-from functools import reduce
-import operator
-from sympy import symbols, sympify
 from PyTorchSimFrontend import extension_config
 from PyTorchSimFrontend import extension_codecache
 from PyTorchSimFrontend.mlir.mlir_codegen_backend import MLIRKernel
@@ -13,8 +9,6 @@ from torch._inductor import config
 from torch._inductor.scheduler import BaseScheduling, FusedSchedulerNode, SchedulerNode, BaseSchedulerNode
 from torch._inductor.utils import IndentedBuffer
 from torch._inductor.virtualized import V
-from torch._inductor.ir import LoopBody
-from torch._inductor import dependencies
 from torch._inductor.codegen.common import BackendFeature
 
 from . import mlir_common
@@ -36,33 +30,12 @@ class MLIRScheduling(BaseScheduling):
         self.max_fusion_size = 5
 
     def can_fuse_with_exceptions(self, node1: BaseSchedulerNode, node2: BaseSchedulerNode) -> bool:
+        # Monkey patch: Inductor's own can_fuse never considers prologue fusion into a
+        # template, so intercept that one shape and ask the template about it.
         if not extension_config.CONFIG_FUSION_PROLOGUE:
             return self.scheduler.can_fuse_origin(node1, node2)
-
-        # Extract base template node
-        base_template_node1 = [node for node in node1.get_nodes() if node.is_template()]
-        base_template_node2 = [node for node in node2.get_nodes() if node.is_template()]
-
-        # Case 3: Prologue(Pointwise) + Tempalte
-        if len(base_template_node1) == 0 and len(node1.get_nodes())==1 and len(node2.get_nodes())==1 and not node1.is_reduction() and len(base_template_node2) == 1 and extension_config.CONFIG_FUSION_PROLOGUE:
-            target_node = base_template_node2[0].node
-
-            # Check if template supports prologue fusion
-            if not getattr(target_node.template, 'support_prologue_fusion', False):
-                return False
-
-            if len(node1.read_writes.writes) != 1:
-                return False
-            if node1.node not in target_node.inputs or any(["view" in str(ori) for ori in node1.node.origins]): #FIXME
-                return False
-
-            # We don't fuse this edge case...
-            if base_template_node2[0].group[1][0][0] == 1:
-                return False
-
-            if list(node1.read_writes.writes)[0].name in [dep.name for dep in node2.read_writes.reads]:
-                node1 = self.revert_group(node1)
-                return True
+        if self._single_prologue_template_pair(node1, node2) is not None:
+            return self._prologue_plan_for(node1, node2) is not None
         return self.scheduler.can_fuse_origin(node1, node2)
 
 
@@ -81,6 +54,51 @@ class MLIRScheduling(BaseScheduling):
 
     def can_fuse_multi_outputs_template(self, node1, node2):
         return self.can_fuse_horizontal(node1, node2)
+
+    def _single_template_epilogue_pair(self, node1, node2):
+        """node1 is a lone template node and node2 a lone non-template node -> that template node."""
+        templates = [n for n in node1.get_nodes() if n.is_template()]
+        if len(templates) != 1 or len(node1.get_nodes()) != 1:
+            return None
+        if len(node2.get_nodes()) != 1 or any(n.is_template() for n in node2.get_nodes()):
+            return None
+        return templates[0]
+
+    def _single_prologue_template_pair(self, node1, node2):
+        """node1 is a lone non-template node feeding a lone template node2 -> that template node."""
+        if len(node1.get_nodes()) != 1 or any(n.is_template() for n in node1.get_nodes()):
+            return None
+        if node1.is_reduction():
+            return None
+        templates = [n for n in node2.get_nodes() if n.is_template()]
+        if len(templates) != 1 or len(node2.get_nodes()) != 1:
+            return None
+        if not ({d.name for d in node1.read_writes.writes} & {d.name for d in node2.read_writes.reads}):
+            return None
+        return templates[0]
+
+    def _epilogue_plan_for(self, node1, node2):
+        """The FusionPlan the template approved for this pair, or None. Pure."""
+        template_node = self._single_template_epilogue_pair(node1, node2)
+        if template_node is None:
+            return None
+        return template_node.node.template.try_fuse_epilogue(node1, [], node2)
+
+    def _prologue_plan_for(self, node1, node2):
+        """The FusionPlan the template approved for prologue-fusing node1 into node2. Pure."""
+        template_node = self._single_prologue_template_pair(node1, node2)
+        if template_node is None:
+            return None
+        return template_node.node.template.try_fuse_prologue(node2, node1)
+
+    def fuse(self, node1, node2):
+        # Commit hook: templates defer their node mutations into the plan so that
+        # can_fuse stays a pure predicate. Recomputing the plan here (it is pure and
+        # cheap) avoids caching it across the many speculative can_fuse calls.
+        plan = self._epilogue_plan_for(node1, node2) or self._prologue_plan_for(node1, node2)
+        if plan is not None and plan.remap is not None:
+            plan.remap()
+        return super().fuse(node1, node2)
 
     def can_fuse_horizontal(self, node1, node2):
         if not extension_config.CONFIG_FUSION:
@@ -104,10 +122,6 @@ class MLIRScheduling(BaseScheduling):
         if '_unsafe_index' in node1.get_nodes()[0].node.origins or "_unsafe_index" in node2.get_nodes()[0].node.origins:
             return False
 
-        # Extract base template node
-        base_template_node1 = [node for node in node1.get_nodes() if node.is_template()]
-        base_template_node2 = [node for node in node2.get_nodes() if node.is_template()]
-
         # Case 0: Reduction fusion
         if (
             node1.is_reduction()
@@ -124,122 +138,17 @@ class MLIRScheduling(BaseScheduling):
             )
             return same_iter and no_dependency
 
-        # Case 1: Template + Pointwise fusion
-        if len(base_template_node1) == 1 and len(node1.get_nodes())==1 and len(node2.get_nodes())==1 and len(base_template_node2) == 0 and not node2.is_reduction():
-            # Don't fuse maxpool template code
-            from PyTorchSimFrontend.mlir.mlir_maxpool_template import MLIRMaxPoolTemplate
+        # Template + epilogue (pointwise or reduction): every condition is the template's.
+        if self._single_template_epilogue_pair(node1, node2) is not None:
+            return self._epilogue_plan_for(node1, node2) is not None
 
-            template_node = base_template_node1[0]
-            epilogue_node = node2
-
-            # Check if template supports epilogue fusion
-            if not getattr(template_node.node.template, 'support_epilogue_fusion', False):
-                return False
-
-            if isinstance(template_node.node.template, MLIRMaxPoolTemplate):
-                return False
-
-            # Pointwise check
-            v1_total = math.prod(vars1) if len(vars1) else 0
-            v2_total = math.prod(vars2) if len(vars2) else 0
-            if v1_total != v2_total:
-                return False
-
-            # Pattern check: check data dependency between act_node and template_node
-            template_sched_nodes = list(template_node.get_nodes())
-            # Buffers produced by the template (its outputs)
-            template_writes = {
-                dep
-                for n in template_sched_nodes
-                for dep in n.read_writes.writes
-            }
-            # Buffers still required by the activation node (unmet) or read by it
-            epilogue_unmet = { dep for dep in epilogue_node.unmet_dependencies }
-            has_dependency = bool(template_writes) and epilogue_unmet.issubset(template_writes) and not bool(reads1 & writes2)
-            if not has_dependency:
-                return False
-
-            # Revert act_node.group : simplify_and_reorder() modified _body, _size, group
-            if template_node.group != epilogue_node.group:
-                # We don't fuse this case...
-                if getattr(template_node.node.template, 'support_prologue_fusion', False) and template_node.group[1][0][0] == 1:
-                    return False
-
-                if list(template_node.group[1][0]) != list(epilogue_node.get_nodes()[0].node.data.get_size()):
-                    return False
-                self.revert_group(epilogue_node)
-            return True
-
-        # Case 2: Tempalte + Reduction fusion
-        if len(base_template_node1) == 1 and len(node1.get_nodes())==1 and len(node2.get_nodes())==1 and len(base_template_node2) == 0 and node2.is_reduction() and extension_config.CONFIG_FUSION_REDUCTION_EPILOGUE:
-            target_node = base_template_node1[0].node
-
-            # Check if template supports reduction fusion
-            if not getattr(target_node.template, 'support_reduction_fusion', False):
-                return False
-
-            size_match = node1.get_nodes()[0].node.get_numel() == reduce(operator.mul, node2.get_nodes()[0].node.get_size(), 1) * reduce(operator.mul, node2.get_nodes()[0].node.get_reduction_size(), 1)
-            target_symbol = symbols("r0_0")
-            try:
-                stride = [i.strip()[:-1].split(",")[-1].strip() for i in str(node2.get_nodes()[0].node).split("\n") if "r0" in i][1]
-                stride = int(sympify(stride).coeff(target_symbol))
-            except:
-                return False
-
-            # We can't fuse dim=-1 & N == 1
-            layout_possible = stride != 1 and (1 not in node1.node.get_size())
-            # Directed linked?
-            dependency_check = writes1 & reads2
-            dependency_size = all([i.get_numel() == node1.get_nodes()[0].node.get_numel() for i in node2.read_writes.reads])
-            return size_match and layout_possible and dependency_check and dependency_size
-
-        # Case 3: Prologue(Pointwise) + Tempalte
-        # if len(base_template_node1) == 0 and len(node1.get_nodes())==1 and not node1.is_reduction() and len(base_template_node2) == 1 and extension_config.CONFIG_FUSION_PROLOGUE:
-        #     from PyTorchSimFrontend.mlir.mlir_gemm_template import MLIRGemmTemplate
-        #     from PyTorchSimFrontend.mlir.mlir_bmm_template import MLIRBMMTemplate
-
-        #    target_node = base_template_node2[0].node
-        #    # Currently only BMM, MM support prologue fusion
-        #    if not isinstance(target_node.template, (MLIRBMMTemplate, MLIRGemmTemplate)):
-        #        return False
-
-        #    if len(node1.read_writes.writes) != 1:
-        #        return False
-        #    if node1.node not in target_node.inputs or any(["view" in str(ori) for ori in node1.node.origins]): #FIXME
-        #        return False
-
-        #    # We don't fuse this edge case...
-        #    if base_template_node2[0].group[1][0][0] == 1:
-        #        return False
-
-        #    if list(node1.read_writes.writes)[0].name in [dep.name for dep in node2.read_writes.reads]:
-        #        node1 = self.revert_group(node1)
-        #        return True
         return False
 
     def revert_group(self, act_nodes, args=None, var_ranges=None):
-        for act_node in act_nodes.get_nodes():
-            if args is None or var_ranges is None:
-                args, var_ranges = dependencies.index_vars_no_squeeze(
-                        act_node.node.data.get_size(), act_node.node.data.get_reduction_size(), prefix="q"
-                )
-            body = LoopBody(
-                act_node.node.get_store_function(),
-                (args if act_node.node.get_reduction_type() else args[:1]),
-                var_ranges,
-                args[0],
-                args[1]
-            )
-            index_size = []
-            reduce_size = []
-            for v, s in var_ranges.items():
-                if v in args[0]:
-                    index_size.append(s)
-                else:
-                    reduce_size.append(s)
-            node_device = act_node.get_device()
-            ranges = (index_size, reduce_size)
-            act_node._sizes, act_node._body, act_node.group = (ranges), body, (node_device, self.group_fn(ranges))
+        # Used by axis-split to re-trace a node over split ranges. Fusion reaches the same
+        # re-derivation through FusionPlan.remap, so it never runs from a can_fuse predicate.
+        from PyTorchSimFrontend.mlir.mlir_template import realign_node_group
+        realign_node_group(act_nodes, args, var_ranges)
 
     def group_fn(self, sizes):
         return tuple(tuple(map(V.graph.sizevars.simplify, s)) for s in sizes)

--- a/PyTorchSimFrontend/mlir/mlir_template.py
+++ b/PyTorchSimFrontend/mlir/mlir_template.py
@@ -10,7 +10,9 @@ from functools import reduce
 import operator
 from collections import OrderedDict
 
-from typing import List, Optional
+import logging
+from dataclasses import dataclass
+from typing import Callable, List, Optional
 from unittest.mock import patch
 
 from PyTorchSimFrontend import extension_config
@@ -91,6 +93,65 @@ class IndentedBufferGroup:
                 yield self
         finally:
             self.restore_buffers()
+
+fusion_log = logging.getLogger(__name__)
+
+
+@dataclass
+class FusionPlan:
+    """What the scheduler must do to commit a fusion that a template approved.
+
+    `MLIRTemplate.try_fuse_*` is a pure predicate (the scheduler calls it speculatively
+    for many candidate pairs), so any node mutation the fusion needs -- a loop merge, a
+    group re-derivation -- is deferred here and applied by `MLIRScheduling.fuse()` once
+    the fusion is actually committed.
+    """
+    remap: Optional[Callable] = None      # zero-arg thunk, invoked from fuse()
+
+
+def realign_node_group(node_to_realign, args=None, var_ranges=None):
+    """Re-derive a node's loop body/sizes/group from its data size.
+
+    `simplify_and_reorder()` may have reordered the node's loops away from the template's
+    iteration order; rebuilding the body puts them back. Used as a `FusionPlan.remap` (so
+    it runs from `MLIRScheduling.fuse()`, never from a can_fuse predicate) and by
+    axis-split, which re-traces a node over split ranges.
+    """
+    from torch._inductor.ir import LoopBody
+    from torch._inductor import dependencies
+    from torch._inductor.virtualized import V as _V
+
+    for node in node_to_realign.get_nodes():
+        if args is None or var_ranges is None:
+            args, var_ranges = dependencies.index_vars_no_squeeze(
+                node.node.data.get_size(), node.node.data.get_reduction_size(), prefix="q")
+        body = LoopBody(
+            node.node.get_store_function(),
+            (args if node.node.get_reduction_type() else args[:1]),
+            var_ranges, args[0], args[1])
+        index_size, reduce_size = [], []
+        for v, s in var_ranges.items():
+            (index_size if v in args[0] else reduce_size).append(s)
+        ranges = (index_size, reduce_size)
+        group = tuple(tuple(map(_V.graph.sizevars.simplify, s)) for s in ranges)
+        node._sizes, node._body, node.group = ranges, body, (node.get_device(), group)
+
+
+def merge_node_loops(node_to_merge):
+    """Collapse a node's contiguous loops so its iteration fits the template's frame."""
+    node_to_merge.get_nodes()[0].merge_loops()
+
+
+def why_no_fuse(template_node, node_to_fuse, reason):
+    """Record why a fusion was declined, and return the 'declined' value (None).
+
+    Declining is a normal outcome -- upstream CUTLASS/CPP decline every reduction
+    epilogue outright -- so every decline carries a reason to keep the decision
+    debuggable (cf. Inductor's WhyNoFuseNames).
+    """
+    fusion_log.debug("cannot fuse %s into template %s: %s", node_to_fuse, template_node, reason)
+    return None
+
 
 class MLIRTemplateKernel(MLIRKernel, BaseMLIRHardwareInfo):
     def __init__(self,
@@ -1378,6 +1439,12 @@ class MLIRTemplateCaller(CUDATemplateCaller):
 class MLIRTemplate(KernelTemplate):
     index_counter = itertools.count()
 
+    # Maps a fused reduction epilogue's loop indices onto this template's tile axes.
+    # `render()` hands it to the kernel, and its LENGTH is the number of loop ranges the
+    # epilogue codegen can address (set_ranges asserts len(dim_aliasing) == len(ranges)).
+    # None means this template cannot absorb a reduction epilogue.
+    REDUCTION_EPILOGUE_ALIASING = None
+
     def __init__(self, name, input_nodes, layout, input_reorder = None):
         """
         Baseclass for MLIR Templates, derived from KernelTemplate. Not to be instantiated directly.
@@ -1399,7 +1466,147 @@ class MLIRTemplate(KernelTemplate):
         # Fusion support flags (default to False)
         self.support_epilogue_fusion = False
         self.support_prologue_fusion = False
-        self.support_reduction_fusion = False
+
+    def try_fuse_epilogue(self, template_node, existing_epilogues, node_to_fuse):
+        """Decide whether `node_to_fuse` can be fused as this template's epilogue.
+
+        Only the template knows its output coordinate frame, so every fusion condition
+        that depends on it lives here -- the scheduler only identifies the template and
+        the direction, then asks. MUST BE PURE: the scheduler calls this speculatively
+        for many candidate pairs, so it may not mutate any node. Anything that has to
+        mutate goes into the returned plan's `remap`, which the scheduler applies from
+        `fuse()` when the fusion is actually committed.
+
+        `existing_epilogues` are the epilogues already fused onto this template (always
+        empty for now; the argument is here so chained epilogue fusion can be enabled
+        later without changing every implementation).
+
+        Returns a FusionPlan to fuse, or None to decline (declining is a normal result:
+        upstream CUTLASS/CPP decline every reduction epilogue outright)."""
+        if existing_epilogues:
+            return why_no_fuse(template_node, node_to_fuse, "chained epilogue fusion is not supported yet")
+        if node_to_fuse.is_reduction():
+            if self.REDUCTION_EPILOGUE_ALIASING is None:
+                return why_no_fuse(template_node, node_to_fuse, "template does not fuse reduction epilogues")
+            return self._try_fuse_reduction_epilogue(template_node, node_to_fuse)
+        if not self.support_epilogue_fusion:
+            return why_no_fuse(template_node, node_to_fuse, "template does not support epilogue fusion")
+        return self._try_fuse_pointwise_epilogue(template_node, node_to_fuse)
+
+    def _try_fuse_reduction_epilogue(self, template_node, epi):
+        """Frame-independent conditions for absorbing a reduction epilogue, plus the one
+        frame-dependent question: does it fit REDUCTION_EPILOGUE_ALIASING? Pure."""
+        def why(reason):
+            return why_no_fuse(template_node, epi, reason)
+
+        if not extension_config.CONFIG_FUSION_REDUCTION_EPILOGUE:
+            return why("reduction-epilogue fusion is disabled")
+        if epi.has_aliasing_or_mutation():
+            return why("epilogue has aliasing or mutation")
+
+        tnode = template_node.get_nodes()[0].node
+        esched = epi.get_nodes()[0]
+        enode = esched.node
+
+        # The epilogue must iterate exactly the template output (rows x reduced cols).
+        if tnode.get_numel() != math.prod(enode.get_size()) * math.prod(enode.get_reduction_size()):
+            return why("epilogue does not iterate the whole template output")
+        if not all(d.get_numel() == tnode.get_numel() for d in epi.read_writes.reads):
+            return why("epilogue reads a buffer whose size differs from the template output")
+
+        # It must read the template output at exactly one index expression (the CPP backend's
+        # template_fusion_with_epilogues_supported applies the same rule). Read the expressions
+        # off the LoopBody: a MemoryDep's index is normalized to a flat contiguous access and
+        # no longer carries the per-axis strides.
+        body = esched._body
+        template_bufs = {d.name for d in template_node.read_writes.writes}
+        read_exprs = {e for name in template_bufs for e in body.get_all_read_expr(name)}
+        if not read_exprs:
+            return why("epilogue does not read the template output")
+        if len(read_exprs) != 1:
+            return why("epilogue reads the template output at more than one index")
+        index = next(iter(read_exprs))
+
+        # The reduced axis must not be the contiguous (stride-1) column, and the output must
+        # not carry a size-1 dim.
+        reduce_vars = body.vars[1]
+        if len(reduce_vars) != 1:
+            return why("more than one reduction axis")
+        if index.coeff(reduce_vars[0]) == 1:
+            return why("reduces the contiguous (stride-1) axis")
+        if 1 in template_node.node.get_size():
+            return why("template output has a size-1 dimension")
+
+        # The only frame-dependent question: does the epilogue's iteration fit the coordinate
+        # map this template's reduction-epilogue codegen addresses? `set_ranges` asserts
+        # len(dim_aliasing) == len(ranges), so the map's length IS the frame's capacity, and
+        # checking it here is that assert, raised as a decline instead of a crash. See #255.
+        addressable = len(self.REDUCTION_EPILOGUE_ALIASING)
+        needed = len(esched._sizes[0]) + len(reduce_vars)
+        if needed <= addressable:
+            return FusionPlan()
+
+        # It does not fit as-is. merge_loops() returns a NEW body, so ask whether merging the
+        # node's contiguous loops would make it fit -- without mutating anything.
+        merged = len(body.merge_loops().sizes[0]) + len(reduce_vars)
+        if merged > addressable:
+            # e.g. ConvNextV2's channels-first LayerNorm reduces the middle C axis, so batch
+            # and spatial are not contiguous and no loop merge can flatten them.
+            return why(f"epilogue needs {needed} loop ranges ({merged} after a loop merge) but "
+                       f"this template's reduction epilogue addresses {addressable}")
+        return FusionPlan(remap=functools.partial(merge_node_loops, epi))
+
+    def _try_fuse_pointwise_epilogue(self, template_node, epi):
+        """Generic (frame-independent) pointwise-epilogue conditions. Pure."""
+        def why(reason):
+            return why_no_fuse(template_node, epi, reason)
+
+        # The epilogue must sweep exactly as many elements as the template output.
+        tmpl_iter, epi_iter = template_node.group[1][0], epi.group[1][0]
+        if (math.prod(tmpl_iter) if len(tmpl_iter) else 0) != (math.prod(epi_iter) if len(epi_iter) else 0):
+            return why("epilogue iterates a different number of elements than the template")
+
+        # Everything the epilogue still needs must come from the template's outputs, and
+        # it must not overwrite anything the template reads.
+        template_writes = {dep for n in template_node.get_nodes() for dep in n.read_writes.writes}
+        if not template_writes:
+            return why("template writes nothing")
+        if not {dep for dep in epi.unmet_dependencies}.issubset(template_writes):
+            return why("epilogue depends on buffers the template does not produce")
+        if {d.name for d in template_node.read_writes.reads} & {d.name for d in epi.read_writes.writes}:
+            return why("epilogue overwrites a buffer the template reads")
+
+        if template_node.group == epi.group:
+            return FusionPlan()
+
+        # simplify_and_reorder() moved the epilogue's loops; they can be put back only if
+        # its data size still matches the template's iteration.
+        if self.support_prologue_fusion and template_node.group[1][0][0] == 1:
+            return why("degenerate first iteration dim on a prologue-fusing template")
+        if list(template_node.group[1][0]) != list(epi.get_nodes()[0].node.data.get_size()):
+            return why("epilogue loop order cannot be realigned to the template")
+        return FusionPlan(remap=functools.partial(realign_node_group, epi))
+
+    def try_fuse_prologue(self, template_node, node_to_fuse):
+        """Prologue counterpart of `try_fuse_epilogue`. Same purity contract.
+
+        The scheduler has already established that `node_to_fuse` is a lone non-template
+        node feeding this lone template node."""
+        def why(reason):
+            return why_no_fuse(template_node, node_to_fuse, reason)
+
+        if not self.support_prologue_fusion:
+            return why("template does not support prologue fusion")
+        if len(node_to_fuse.read_writes.writes) != 1:
+            return why("prologue writes more than one buffer")
+        target = template_node.get_nodes()[0].node
+        if node_to_fuse.node not in target.inputs:
+            return why("prologue output is not a template input")
+        if any("view" in str(origin) for origin in node_to_fuse.node.origins):
+            return why("prologue is a view")
+        if template_node.group[1][0][0] == 1:
+            return why("template has a degenerate first iteration dim")
+        return FusionPlan(remap=functools.partial(realign_node_group, node_to_fuse))
 
     def generate(self, **kwargs) -> ChoiceCaller:
         kernel_name = f"mlir_{self.name}"

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ PyTorchSim **supports**:
 | DeepSeek-V3 (base) | 🤗 | ✅ | `tests/models/DeepSeek/` — several ops(e.g., gate ops) are not cycle-modeled |
 | SwinV2 | 🤗 | ✅ | `tests/models/test_swinv2.py` (shifted-window attention) |
 | CLIP (vision) | 🤗 | ✅ | `tests/models/test_clip.py` |
+| ConvNeXt V2 | 🤗 | ✅ | `tests/models/test_convnextv2.py` (channels-first LayerNorm, depthwise conv) |
 | Llama-4 | 🤗 | ⏳ | In development |
 | Broader model support | — | ⏳ | In development |
 <!-- ## Requirements

--- a/tests/models/test_convnextv2.py
+++ b/tests/models/test_convnextv2.py
@@ -1,0 +1,67 @@
+import argparse
+import os
+import sys
+
+import torch
+from transformers import ConvNextV2Config, ConvNextV2Model
+
+sys.path.insert(0, os.path.join(os.environ.get("TORCHSIM_DIR", default="/workspace/PyTorchSim"), "tests"))
+from _pytorchsim_utils import test_result
+
+
+def _init_weights(m):
+    if isinstance(m, torch.nn.Linear):
+        torch.nn.init.normal_(m.weight, mean=0.0, std=0.02)
+        if m.bias is not None:
+            torch.nn.init.zeros_(m.bias)
+    elif isinstance(m, torch.nn.Conv2d):
+        torch.nn.init.normal_(m.weight, mean=0.0, std=0.02)
+        if m.bias is not None:
+            torch.nn.init.zeros_(m.bias)
+    elif isinstance(m, torch.nn.LayerNorm):
+        if m.weight is not None:
+            torch.nn.init.ones_(m.weight)
+        if m.bias is not None:
+            torch.nn.init.zeros_(m.bias)
+
+
+def test_convnextv2(device, batch=2, image_size=64, patch_size=4):
+    """ConvNeXt V2 with batch > 1. Two things used to break here (GitHub issue #255):
+    the channels-first LayerNorm reduces the contiguous axis, which the GEMM template's
+    2-D reduction-epilogue frame cannot express, and the depthwise 7x7 conv lowers to
+    gather kernels whose index-expression scratch buffer exhausted the SPAD budget."""
+    torch.manual_seed(0)
+    cfg = ConvNextV2Config(
+        depths=[1, 1, 1, 1],
+        hidden_sizes=[96, 192, 384, 768],
+        image_size=image_size,
+        patch_size=patch_size,
+    )
+    with torch.no_grad():
+        model = ConvNextV2Model(cfg).eval()
+        model.apply(_init_weights)
+
+        x = torch.randn(batch, 3, image_size, image_size)
+        out_cpu = model(pixel_values=x.cpu()).last_hidden_state
+
+        model.to(device)
+        opt_model = torch.compile(dynamic=False)(model)
+        out_device = opt_model(pixel_values=x.to(device)).last_hidden_state
+
+    test_result(f"ConvNeXt V2 (batch={batch})", out_device, out_cpu)
+    print("Max diff >", torch.max(torch.abs(out_device.cpu() - out_cpu)))
+    print("ConvNeXt V2 Simulation Done")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run ConvNeXt V2 test")
+    parser.add_argument("--batch", type=int, default=2)
+    parser.add_argument("--image_size", type=int, default=64)
+    parser.add_argument("--patch_size", type=int, default=4)
+    args = parser.parse_args()
+    test_convnextv2(
+        torch.device("npu:0"),
+        batch=args.batch,
+        image_size=args.image_size,
+        patch_size=args.patch_size,
+    )

--- a/tests/ops/fusion/test_matmul_reduction.py
+++ b/tests/ops/fusion/test_matmul_reduction.py
@@ -25,6 +25,21 @@ def test_matmul_reduce(device, M=512, N=512, K=512):
     test_result("Matmul Reduction Fusion activation", res[0], y[0])
     test_result("Matmul Reduction Fusion reduction", res[1], y[1])
 
+def test_matmul_reduce_last_dim(device, M=256, N=96, K=96):
+    """Reducing the matmul output's contiguous (last) axis cannot be expressed in the GEMM's
+    2-D reduction-epilogue frame, so the reduction has to run as its own kernel. Fusing it
+    anyway silently produces wrong values, so this only checks the numbers."""
+    def matmul_fused(a, b):
+        result = torch.matmul(a, b)
+        return result - result.mean(dim=-1, keepdim=True)
+    torch.manual_seed(0)
+    input = torch.randn(M, K)
+    weight = torch.randn(K, N)
+    opt_fn = torch.compile(dynamic=False)(matmul_fused)
+    res = opt_fn(input.to(device=device), weight.to(device=device))
+    y = matmul_fused(input.to("cpu"), weight.to("cpu"))
+    test_result("Matmul reduce over contiguous axis", res, y)
+
 def test_matmul_var_mean(device, size=512):
     def matmul_fused(a, b, c):
         result = torch.matmul(a, b.T)
@@ -76,5 +91,6 @@ def test_matmul_add_var_mean(device, M=768, N=512, K=3072):
 if __name__ == "__main__":
     device = torch.device("npu:0")
     test_matmul_reduce(device, 3072, 512, 768)
+    test_matmul_reduce_last_dim(device)
     test_matmul_var_mean(device)
     test_matmul_add_var_mean(device)


### PR DESCRIPTION
Fixes #255. ConvNeXt V2 with `batch > 1` died at codegen with `AssertionError: Index names length mismatch: 2 != 3`. Two independent frontend bugs were stacked behind that message; the second only became visible once the first was fixed. `batch=2` now matches CPU end to end, **max abs diff 5.0e-06**.

---

## 1. The fusion gate read the reduction stride out of a repr string

`can_fuse_horizontal` decided whether a reduction epilogue could be folded into a GEMM by parsing the node's `repr()`:

```python
[i.strip()[:-1].split(",")[-1].strip() for i in str(node).split("\n") if "r0" in i][1]
```

The intent was right: a reduction over the output's contiguous (stride-1) axis cannot be expressed in the GEMM template's 2-D reduction-epilogue frame, so it must not fuse. But taking the *second* line containing `"r0"` lands on the wrong index expression once the node has more than two dimensions. ConvNeXt V2's channels-first LayerNorm mean is exactly that shape, so it was let through, and `set_ranges` (`mlir_common.py:584`) asserted `len(dim_aliasing) == len(ranges)` -> `2 != 3`.

### The fix: templates own their own fusion conditions

Rather than repair the string parse, the decision layer now follows the pattern both upstream Inductor backends use (`CUDACPPScheduling._can_fuse_epilogue_impl` for CUTLASS, `template_fusion_with_epilogues_supported` for CPP): `can_fuse` stays **pure**, expressibility is judged **from the IR**, and declining is cheap and logged.

- `MLIRTemplate.try_fuse_epilogue(template_node, existing_epilogues, node_to_fuse)` and `try_fuse_prologue(...)` own every frame-dependent condition, config gates included, and return `FusionPlan | None`. They are pure, so the scheduler can call them speculatively.
- Mutations (loop merges, group realignment) are deferred into `FusionPlan.remap`, a zero-arg thunk applied from `MLIRScheduling.fuse()` -- the commit hook `Scheduler.fuse_nodes_once` already calls.
- The scheduler keeps only graph facts (`_single_template_epilogue_pair`, `_single_prologue_template_pair`) and delegates. It loses 155 lines.
- Every decline goes through `why_no_fuse()` and logs a reason at DEBUG on `PyTorchSimFrontend.mlir.mlir_template`.

The stride check now reads the real index expression via `LoopBody.get_all_read_expr(buffer_name)` and the real reduction symbol via `body.vars[1]`. Note that `MemoryDep.index` **cannot** be used here: it is normalized to a flat contiguous access and carries no per-axis strides, so `index.coeff(reduce_var)` is always 0, which silently disables the check and produces wrong values rather than a crash. That is presumably why the original parsed the repr.

### `REDUCTION_EPILOGUE_ALIASING`

The coordinate map that `render()` already used is hoisted to a class attribute. Its **length is exactly what `set_ranges` asserts against**, so the fusion gate *is* that assert, raised early as a decline instead of late as a crash. `None` means the template cannot absorb a reduction epilogue at all, which retires the `support_reduction_fusion` flag. GEMM declares 2 entries (row + reduced N), BMM declares 3 (batch + row + reduced N) -- that length is the only difference between them, so the conditions live in the base class and `mlir_gemm_template.py` ends up with no fusion logic at all.

When the epilogue needs more loop ranges than the frame addresses, the template asks `body.merge_loops()` (which is pure, unlike `SchedulerNode.merge_loops()`) whether collapsing would make it fit; if so the merge becomes the `plan.remap`. For ConvNeXt V2 it correctly refuses -- the reduced C axis sits between batch and spatial in the channels-first layout, so the rows are not contiguous -- and the reduction runs as its own kernel.

## 2. The index-expression scratch buffer was sized per tile, not per lane

With the LayerNorm reduction now correctly running as its own kernel, ConvNeXt V2 hit `SpadOverflowError`.

Spad globals follow a fixed convention, visible in `codegen_spad_buffer()` (`mlir_codegen_backend.py:1552-1553`):

| | value | meaning |
|---|---|---|
| MLIR `memref.global` | `tile_desc.get_mlir_shape()` | full tile, all lanes |
| `.spad` C header (Spike links this) | `tile_size // vector_lane` | **per lane** |
| gem5 C header | `tile_size` | full tile |

`index_expr()` had the two headers **swapped**. The iota buffer (`[0, 1, ..., compute_vec_size-1]`) it allocates for vectorized index arithmetic declared `compute_vec_size * vector_lane` entries in the `.spad` header and `compute_vec_size` in the gem5 header. So Spike's buffer is `vector_lane` times too large, and gem5's is one element too small -- the initializer stores two elements per iteration (`ops.broadcast(init_iter, 2)`, kept wide to avoid scalar ops), so its last iteration writes one slot past `compute_vec_size`.

Only `[0, compute_vec_size)` is ever touched: one `affine.parallel (%i) = (0) to (compute_vec_size)` writes it, one `affine.vector_load %buf[0] : vector<compute_vec_size x index>` reads it.

Since the spad guard tightened to `spad/2` for double buffering, the oversize side is fatal. ConvNeXt V2's `var_mean` kernel:

| symbol | bytes/lane |
|---|---|
| `buf0..buf3` (data tiles) | 16384 |
| `buf4, buf5` (mean/var out) | 64 |
| `index_expr_64_spad[8192]` | **65536** |
| total | **81984** (budget 65536) |

The real data is 16 KB; an iota that uses 64 entries (512 B) exhausts the whole budget. The heuristic mapping path has no tile-shrink fallback -- `SpadOverflowError` is only caught inside `autotune()` -- so this is a hard failure.

The fix declares `compute_vec_size + 1` entries per lane and `vector_lane` times that for gem5. The `+1` is the two-wide initializer store, made explicit in a comment; it is the same slack idea as `max(tile_numel_per_lane, 2)` in `codegen_spad_buffer()`. The `var_mean` kernel now measures 16968 bytes/lane, and every other `index_expr` kernel shrinks by the same factor (`index_expr_16_spad`: 2048 entries -> 17).

The MLIR `memref` type is left alone: it already carries the full-tile count, matching the convention, and the `.ll` declares the symbol `external` so the C header is what defines the storage.

## 3. `SpadOverflowError` now says which kernel overflowed

It was raised with no arguments and the only diagnostic was an off-by-default `logger.debug`, so a failing compile printed `SPAD overflow occurred.` and nothing else. `load()` already has the measured usage, the budget, the tile size and the kernel's origins in scope. That is how the kernel above was identified.

## 4. Test, CI, coverage

`tests/models/test_convnextv2.py` (batch=2, `depths=[1,1,1,1]`, `image_size=64`), a self-hosted CI job, and a README coverage row.

---

## Verification

- **ConvNeXt V2 batch=2**: functional mode (Spike) vs CPU, `Test Passed`, max abs diff `5.0068e-06`.
- **Depthwise 7x7 conv** (`conv2d(x, w, b, padding=3, groups=96)`), the smallest op that emits `index_expr`: functional mode, rebuilt binaries, max abs diff `7.6e-06`. This exercises the resized buffer end to end and rules out an alignment regression from the smaller allocation.
- **`tests/ops/fusion/`**: `test_matmul_reduction`, `test_bmm_reduction`, `test_matmul_activation`, `test_conv_fusion`, `test_prologue_fusion` all still compile with their expected fused `origins` (e.g. `mm, max_1` and `bmm, max_1`). Worth watching on review: BMM also supports reduction fusion, so putting the reduction conditions in the GEMM template alone silently splits `test_bmm_reduction` into two kernels.
- **New regression test** `tests/ops/fusion/test_matmul_reduction.py::test_matmul_reduce_last_dim`: a matmul whose reduction is over the contiguous axis must not fuse. Fusing it anyway returns wrong values rather than failing to compile, so the test checks numbers. Every pre-existing test reduces `dim=-2` (a non-contiguous axis), so this hole existed.

The original ConvNeXt V2 crash has **no self-contained repro** -- `matmul+permute+mean`, `+addmm`, and a full channels-first LayerNorm all fail to reproduce it, because the trigger needs a node with more than two dims whose second `"r0"` line is the wrong one. Rather than fabricate one, the model test guards it.

## Follow-ups (not in this PR)

- Chained epilogue fusion is still unsupported. `try_fuse_epilogue` already takes `existing_epilogues`, so enabling it only needs the scheduler's single-node gate relaxed (upstream CUTLASS does this).
- `support_epilogue_fusion` / `support_prologue_fusion` remain as declarative gates inside the template layer.