### PR TITLE
[TOGSim] Do not rescan the blocked head of the ready queue on every issue

### DIFF
--- a/TOGSim/include/Core.h
+++ b/TOGSim/include/Core.h
@@ -137,6 +137,9 @@ class Core {
   // to its accumulated footprint bytes (freed when its last reader issues).
   size_t _sram_used = 0;
   size_t _sram_capacity = 0;
+  // Free SA weight slots. With _sram_used it keys the issue scan's cursor: an
+  // instruction it walked past wakes only if one of the two grows.
+  int _weight_free = 0;
   std::unordered_map<int64_t, size_t> _sram_allocs;
 
   // SA weight-buffer throttle (sec 10.4). _weight_slots_used[s] = weights resident

--- a/TOGSim/include/Tile.h
+++ b/TOGSim/include/Tile.h
@@ -39,6 +39,25 @@ class Tile : public std::enable_shared_from_this<Tile> {
   std::deque<std::shared_ptr<Instruction>>& get_instructions() { return _instructions; } 
   void enqueue_ready(const std::shared_ptr<Instruction>& inst) { _ready_queue.push_back(inst); }
   std::list<std::shared_ptr<Instruction>>& get_ready_instructions() { return _ready_queue; }
+
+  // Issue-scan cursor (Core::cycle): the scan only walks past instructions blocked on
+  // free spad bytes or a free weight slot, so it can resume where it left off.
+  using ReadyIt = std::list<std::shared_ptr<Instruction>>::iterator;
+  ReadyIt scan_from(size_t sram_used, int weight_free) {
+    if (_scan_blocked && sram_used >= _scan_sram_used && weight_free <= _scan_weight_free)
+      return std::next(_scan_blocked_at);
+    return _ready_queue.begin();   // a resource grew -> the prefix may issue now
+  }
+  void note_blocked(ReadyIt it, size_t sram_used, int weight_free) {
+    _scan_blocked_at = it;
+    _scan_blocked = true;
+    _scan_sram_used = sram_used;     // it could not issue with this much spad free...
+    _scan_weight_free = weight_free; // ...nor with this many weight slots free
+  }
+  // Kept across a rescan (the prefix blocks again once the freed resource is taken);
+  // it only dies with its instruction.
+  bool is_scan_cursor(ReadyIt it) const { return _scan_blocked && it == _scan_blocked_at; }
+  void drop_scan_cursor() { _scan_blocked = false; }
   void print();
   size_t nr_insts() { return _nr_insts; }
   size_t nr_finshed_insts() { return _nr_finished_insts; }
@@ -61,6 +80,12 @@ class Tile : public std::enable_shared_from_this<Tile> {
   size_t _nr_finished_insts = 0;
   std::deque<std::shared_ptr<Instruction>> _instructions;
   std::list<std::shared_ptr<Instruction>> _ready_queue;
+  // Only dereferenced while resources are no better than at note_blocked, and a
+  // still-blocked instruction is never erased.
+  ReadyIt _scan_blocked_at;
+  bool _scan_blocked = false;
+  size_t _scan_sram_used = 0;
+  int _scan_weight_free = 0;
   std::vector<std::shared_ptr<Tile>> _child_tiles;
   void *_custom_data=NULL;
   bool _stonne_tile=false;

--- a/TOGSim/src/Core.cc
+++ b/TOGSim/src/Core.cc
@@ -24,6 +24,7 @@ Core::Core(uint32_t id, SimulationConfig config)
     exit(EXIT_FAILURE);
   }
   _weight_slots_used.resize(_num_systolic_array_per_core, 0);
+  _weight_free = _num_systolic_array_per_core * (int)_weight_slot_depth;
 }
 
 // Round-robin a systolic array that still has a free weight slot; -1 if all full
@@ -42,7 +43,7 @@ int Core::pick_free_weight_sa() {
 void Core::apply_due(const DueAction& a) {
   switch (a.kind) {
     case DueAction::FreeWeightSlot:
-      if (--a.token->refcount <= 0) { _weight_slots_used[a.token->sa]--; _issue_dirty = true; }  // weight slot freed -> re-arm
+      if (--a.token->refcount <= 0) { _weight_slots_used[a.token->sa]--; _weight_free++; _issue_dirty = true; }  // weight slot freed -> re-arm
       break;
     case DueAction::WakeBar: {
       auto bar = a.bar;            // async load data arrived -> fire its MEMORY_BAR
@@ -286,7 +287,8 @@ void Core::cycle() {
 
   for (int i=0; i<_tiles.size() && !issued; i++) {
     auto& instructions = _tiles[i]->get_ready_instructions();
-    for (auto it=instructions.begin(); it!=instructions.end();) {
+    // Resume after the prefix already known to be blocked (Tile::scan_from).
+    for (auto it=_tiles[i]->scan_from(_sram_used, _weight_free); it!=instructions.end();) {
       auto& inst = *it;
 
       switch (inst->get_opcode()) {
@@ -365,6 +367,7 @@ void Core::cycle() {
                   exit(EXIT_FAILURE);
                 }
                 _weight_slots_used[sa_idx]++;
+                _weight_free--;
                 auto tok = std::make_shared<WeightToken>(WeightToken{sa_idx, n_consumers});
                 for (auto& c : inst->get_deps(DepEvent::ISSUE))
                   if (c->get_compute_type() == MATMUL) {
@@ -408,6 +411,7 @@ void Core::cycle() {
               inst->finish_instruction();
               static_cast<Tile*>(inst->get_owner())->inc_finished_inst();
               _stat_tot_skipped_inst.at(static_cast<size_t>(inst->get_opcode()))++;
+              if (_tiles[i]->is_scan_cursor(it)) _tiles[i]->drop_scan_cursor();
               it = instructions.erase(it);   // erase returns the next iterator; the
               continue;                      // old code fell through to it++ on the
                                              // erased (invalidated) iterator -> UB
@@ -461,9 +465,12 @@ void Core::cycle() {
 
       if (issued) {
         _stat_inst_count.at(static_cast<size_t>(inst->get_opcode()))++;
+        if (_tiles[i]->is_scan_cursor(it)) _tiles[i]->drop_scan_cursor();
         instructions.erase(it);
         break;
       }
+      // Did not issue -> blocked on spad or a weight slot (the only two stalls).
+      _tiles[i]->note_blocked(it, _sram_used, _weight_free);
       it++;
     }
   }


### PR DESCRIPTION
Follow-up to #301. That PR stopped the 8x8 conv2d from running out of memory, but
`test-pytorchsim-wrapper3 / Run test_conv2d.py` still fails: the simulation itself
does not finish inside the 3h job limit. This is the missing half.

## The problem

`Core::cycle`'s issue scan walks the ready queue from the front every cycle and
issues the first instruction it can. The ones it walks past are blocked -- and only
ever on one of two things: free spad bytes (`try_occupy_sram`) or a free SA weight
slot (`pick_free_weight_sa`). Every other path in the scan issues. So the scan
re-walked the same blocked prefix on its way to every single issue.

On the 8x8 config the array is small, so preloads sit waiting on weight slots and
the blocked prefix grows to ~6000. Counted:

| case | steps walked | issues | steps per issue |
|---|---|---|---|
| CM16 | 762,271,822 | 232,072 | 3284 |
| MM16 | 1,070,436,422 | 302,112 | 3543 |

## The fix

Give each `Tile` a cursor at the last instruction the scan found blocked, and let
the next scan resume after it.

The subtle part is when the cursor is still good. Keying it on "was a resource
freed?" is not enough: a freed weight slot that the woken preload immediately takes
leaves the rest of the prefix blocked, yet the cursor would have been thrown away
and the prefix re-walked. So the cursor is keyed on the resource *levels*
(`_sram_used`, `_weight_free`) at the time it was set -- blocked stays blocked for
as long as neither grew. It is dropped only when its own instruction is erased. New
ready instructions are appended, so they always land after the cursor.

| case | steps walked | steps per issue |
|---|---|---|
| CM16 | 257,156 | 1.11 |
| MM16 | 402,460 | 1.33 |

## Result

The 8x8 `test_conv2d.py` case (batch 2, 128->512, 14x14, k7) goes from **4h36m to
7m19s**.

The scan issues the same instruction on the same cycle -- it just stops re-deriving
what it already knew. Total execution cycles are identical on every case checked:

- weight-slot arm (8x8, spad throttle off): CM16 803,796 / MM16 803,345 /
  MM36 9,835,778 / CI36 39,449,132
- spad arm (128x128 with `core_spad_size_kb` cut to 1024/512 so `try_occupy_sram`
  actually stalls -- the cycle counts shift, confirming the throttle is live):
  CM16 803,296 / MM16 803,345 / MM36 9,838,863, before and after

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEFKqEkhwSurePkBTAmeTU