### PR TITLE
[Config] Add the missing dense-path keys to the heterogeneous config

### DIFF
--- a/configs/heterogeneous_c2_simple_noc.yml
+++ b/configs/heterogeneous_c2_simple_noc.yml
@@ -8,10 +8,14 @@ core_stats_print_period_cycles: 10000
 num_stonne_per_core: 8
 num_stonne_port: 64
 num_systolic_array_per_core: 2
+core_spad_size_kb: 16384
 
 vpu_num_lanes: 128
 vpu_spad_size_kb_per_lane: 128
 vpu_vector_length_bits: 256
+
+pytorchsim_functional_mode: 1
+pytorchsim_timing_mode: 1
 
 dram_type: ramulator2
 dram_freq_mhz: 940


### PR DESCRIPTION
## Problem

`scripts/stonne_experiment/run.sh` runs three STONNE experiments. The third one --
the heterogeneous run (`test_hetro.py --mode 2`, sparse core + dense core on two
partitions) -- currently dies as soon as the dense matmul kernel is launched:

```
File "PyTorchSimFrontend/extension_codecache.py", line 322, in run_kernel_simulation
  if extension_config.pytorchsim_functional_mode and not autotune:
File "PyTorchSimFrontend/extension_config.py", line 57, in __getattr__
  return config_yaml['pytorchsim_functional_mode']
KeyError: 'pytorchsim_functional_mode'
```

`configs/heterogeneous_c2_simple_noc.yml` is missing three keys that the dense
(`ws_mesh`) path requires: `pytorchsim_functional_mode`, `pytorchsim_timing_mode`
and `core_spad_size_kb`. This is config bit-rot -- the file was last touched by a
DRAM-config change and never picked up keys that later became mandatory. The
sparse-only (`--mode 0`) and dense-only (`--mode 1`) experiments were unaffected
because they use different config files.

## Fix

Add the three keys. Values match
`systolic_ws_128x128_c1_simple_noc_tpuv3_half.yml`, the config the dense-only
experiment already uses. `core_spad_size_kb: 16384` is consistent with the
128 lanes x 128 KB per lane this file already declares.

## Verification

On `develop` (e6713711), all three experiments from `run.sh` at M=N=K=1024,
sparsity 0.9:

| mode | config | before | after |
|---|---|---|---|
| 0 (sparse only) | stonne_big_c1_simple_noc | 26696 cycles | unchanged |
| 1 (dense only) | systolic_ws_128x128_..._tpuv3_half | 81720 cycles | unchanged |
| 2 (heterogeneous) | heterogeneous_c2_simple_noc | KeyError | 48177 cycles |

The standalone sparse path (`tests/system/test_stonne.py`) was also checked and
scales with sparsity as expected -- at size 32: 50990 / 28022 / 8488 cycles at
sparsity 0.0 / 0.4 / 0.8.

## Note (not fixed here)

`scripts/stonne_experiment/run_trace.sh` greps for `Stonne Core [0] : Total cycle`
but the simulator now prints `StonneCore [0] : Total cycle` (no space), so that
script silently reports empty cycle counts. It also hardcodes `/workspace/PyTorchSim`
and runs the same script twice while labelling one row "TOG". Left alone since the
original intent is unclear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3QZ8xomsrbs4SoA5wLQvJ